### PR TITLE
Feat: 레시피 대시보드 조회

### DIFF
--- a/src/main/java/com/eateum/eateumbe/global/constant/RecipeCategory.java
+++ b/src/main/java/com/eateum/eateumbe/global/constant/RecipeCategory.java
@@ -1,0 +1,27 @@
+package com.eateum.eateumbe.global.constant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+@AllArgsConstructor
+public enum RecipeCategory {
+
+    KOREAN("korean", "한식"),
+    WESTERN("western", "양식"),
+    JAPANESE("japanese", "일식"),
+    CHINESE("chinese", "중식"),
+    BUNSIK("bunsik", "분식");
+
+    private final String enCategory; //JSON
+    private final String krCategory; //DB
+
+    public static RecipeCategory getRecipeCategory(String krCategory) {
+        return Arrays.stream(RecipeCategory.values())
+                .filter(category -> category.krCategory.equals(krCategory))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("해당되는 레시피 카테고리 없음")); // 해당 카테고리 아니면 예외 던지는 것으로
+    }
+}

--- a/src/main/java/com/eateum/eateumbe/recipes/controller/RecipeController.java
+++ b/src/main/java/com/eateum/eateumbe/recipes/controller/RecipeController.java
@@ -8,7 +8,6 @@ import com.eateum.eateumbe.recipes.dto.response.RecipeDetailResponse;
 import com.eateum.eateumbe.recipes.dto.response.RecipeResponse;
 import com.eateum.eateumbe.recipes.service.RecipeService;
 import lombok.RequiredArgsConstructor;
-import org.apache.ibatis.annotations.Param;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;

--- a/src/main/java/com/eateum/eateumbe/recipes/controller/RecipeController.java
+++ b/src/main/java/com/eateum/eateumbe/recipes/controller/RecipeController.java
@@ -3,10 +3,12 @@ package com.eateum.eateumbe.recipes.controller;
 import com.eateum.eateumbe.global.common.ApiResponse;
 import com.eateum.eateumbe.global.common.PageResponse;
 import com.eateum.eateumbe.recipes.dto.request.RecipeRequest;
+import com.eateum.eateumbe.recipes.dto.response.RecipeDashboardResponse;
 import com.eateum.eateumbe.recipes.dto.response.RecipeDetailResponse;
 import com.eateum.eateumbe.recipes.dto.response.RecipeResponse;
 import com.eateum.eateumbe.recipes.service.RecipeService;
 import lombok.RequiredArgsConstructor;
+import org.apache.ibatis.annotations.Param;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -68,4 +70,10 @@ public class RecipeController {
         return ApiResponse.success(result);
     }
 
+    @GetMapping("my/dashboard")
+    public ApiResponse<RecipeDashboardResponse> getDashboardRecipes() {
+        Long userId = getCurrentUserId();
+        RecipeDashboardResponse response = recipeService.getRecipeDashboard(userId);
+        return ApiResponse.success(response);
+    }
 }

--- a/src/main/java/com/eateum/eateumbe/recipes/domain/Recipe.java
+++ b/src/main/java/com/eateum/eateumbe/recipes/domain/Recipe.java
@@ -18,7 +18,8 @@ public class Recipe {
     private List<RecipeItem> items;
     private List<RecipeStep> steps;
 
-    private Long categoryId; // 관련 영상 조회?? TODO : 수정하기
+    private Long categoryId;
+    private String categoryName;
 
     @Getter
     @NoArgsConstructor

--- a/src/main/java/com/eateum/eateumbe/recipes/dto/response/RecipeDashboardResponse.java
+++ b/src/main/java/com/eateum/eateumbe/recipes/dto/response/RecipeDashboardResponse.java
@@ -1,0 +1,62 @@
+package com.eateum.eateumbe.recipes.dto.response;
+
+import com.eateum.eateumbe.global.constant.RecipeCategory;
+import com.eateum.eateumbe.recipes.domain.Recipe;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecipeDashboardResponse {
+
+    private Long completedCount;
+    private Long likedCount;
+    private Integer period;
+
+    private List<MonthlyCount> completedMonthlyStats;
+
+    private Map<String, Integer> likedCategoryPercent;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MonthlyCount{
+        private Integer month;
+        private Long count;
+
+        public static MonthlyCount from(Integer month, Long count) {
+            return MonthlyCount.builder().month(month).count(count).build();
+        }
+    }
+
+    public static RecipeDashboardResponse from(Long completedCount,
+                                               Long likedCount,
+                                               Integer period,
+                                               List<MonthlyCount> monthlyStats,
+                                               Map<String, Integer> dbCategoryMap) {
+        return RecipeDashboardResponse.builder()
+                .completedCount(completedCount)
+                .likedCount(likedCount)
+                .period(period)
+                .completedMonthlyStats(monthlyStats)
+                .likedCategoryPercent(convertToJsonMap(dbCategoryMap))
+                .build();
+    }
+
+    private static Map<String, Integer> convertToJsonMap(Map<String, Integer> dbMap) {
+        return dbMap.entrySet().stream()
+                .collect(Collectors.toMap(
+                        entry -> RecipeCategory.getRecipeCategory(entry.getKey()).getEnCategory(),
+                        Map.Entry::getValue
+                ));
+    }
+}

--- a/src/main/java/com/eateum/eateumbe/recipes/dto/response/RecipeDashboardResponse.java
+++ b/src/main/java/com/eateum/eateumbe/recipes/dto/response/RecipeDashboardResponse.java
@@ -1,7 +1,6 @@
 package com.eateum.eateumbe.recipes.dto.response;
 
 import com.eateum.eateumbe.global.constant.RecipeCategory;
-import com.eateum.eateumbe.recipes.domain.Recipe;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/eateum/eateumbe/recipes/repository/RecipeMapper.java
+++ b/src/main/java/com/eateum/eateumbe/recipes/repository/RecipeMapper.java
@@ -4,7 +4,9 @@ import com.eateum.eateumbe.recipes.domain.Recipe;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 @Mapper
 public interface RecipeMapper {
@@ -41,6 +43,12 @@ public interface RecipeMapper {
 
     // 좋아요 레시피 갯수 조회
     int countLikedRecipes(@Param("userId") Long userId);
+
+    // 6개월 완성 레시피 통게
+    List<Map<String, Object>> selectMonthlyCompletedStats(@Param("userId") Long userId, @Param("startDate") LocalDateTime startDate);
+
+    // 좋아요 카테고리 비율 통계
+    List<Map<String, Object>> selectLikedCategoryStats(@Param("userId") Long userId);
 
 }
 

--- a/src/main/java/com/eateum/eateumbe/recipes/service/RecipeService.java
+++ b/src/main/java/com/eateum/eateumbe/recipes/service/RecipeService.java
@@ -2,6 +2,7 @@ package com.eateum.eateumbe.recipes.service;
 
 import com.eateum.eateumbe.global.common.PageResponse;
 import com.eateum.eateumbe.recipes.dto.request.RecipeRequest;
+import com.eateum.eateumbe.recipes.dto.response.RecipeDashboardResponse;
 import com.eateum.eateumbe.recipes.dto.response.RecipeDetailResponse;
 import com.eateum.eateumbe.recipes.dto.response.RecipeResponse;
 
@@ -23,4 +24,7 @@ public interface RecipeService {
 
     //  완성 or 좋아요 에 따른 조회(마이페이지)
     PageResponse<RecipeResponse.Status> getStatusRecipes(Long userId, String status, int page, int size);
+
+    // 레시피 대시보드
+    RecipeDashboardResponse getRecipeDashboard(Long userId);
  }

--- a/src/main/java/com/eateum/eateumbe/recipes/service/RecipeServiceImpl.java
+++ b/src/main/java/com/eateum/eateumbe/recipes/service/RecipeServiceImpl.java
@@ -1,10 +1,12 @@
 package com.eateum.eateumbe.recipes.service;
 
 import com.eateum.eateumbe.global.common.PageResponse;
+import com.eateum.eateumbe.global.constant.RecipeCategory;
 import com.eateum.eateumbe.memo.dto.response.MemoResponse;
 import com.eateum.eateumbe.memo.service.MemoService;
 import com.eateum.eateumbe.recipes.domain.Recipe;
 import com.eateum.eateumbe.recipes.dto.request.RecipeRequest;
+import com.eateum.eateumbe.recipes.dto.response.RecipeDashboardResponse;
 import com.eateum.eateumbe.recipes.dto.response.RecipeDetailResponse;
 import com.eateum.eateumbe.recipes.dto.response.RecipeResponse;
 import com.eateum.eateumbe.recipes.repository.RecipeMapper;
@@ -12,8 +14,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
-import java.util.List;
+import java.time.LocalDateTime;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -134,5 +136,68 @@ public class RecipeServiceImpl implements RecipeService {
 
         return PageResponse.of(items, totalItems, page, size);
 
+    }
+
+    @Override
+    public RecipeDashboardResponse getRecipeDashboard(Long userId) {
+
+        // 6개월
+        int period = 6;
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime startDate = now.minusMonths(period - 1);
+
+        long completedCount = recipeMapper.countCompletedRecipes(userId);
+        long likedCount = recipeMapper.countLikedRecipes(userId);
+
+        // 원별 완료 통계 부분
+        List<Map<String, Object>> monthlyCompletedRawData = recipeMapper.selectMonthlyCompletedStats(userId, startDate);
+
+        Map<Integer, Long> monthlyCompletedMap = new HashMap<>();
+        for (Map<String, Object> data : monthlyCompletedRawData) {
+            int month = ((Number) data.get("month")).intValue();
+            long count = ((Number) data.get("count")).longValue();
+            monthlyCompletedMap.put(month, count);
+        }
+
+        List<RecipeDashboardResponse.MonthlyCount> monthlyCompletedStats = new ArrayList<>();
+
+        for (int i = 0; i < period; i++) {
+            LocalDateTime targetDate = startDate.plusMonths(i);
+            int targetMonth = targetDate.getMonthValue(); //달(month) 숫자만 출력
+            long count = monthlyCompletedMap.getOrDefault(targetMonth, 0L);
+
+            monthlyCompletedStats.add(RecipeDashboardResponse.MonthlyCount.from(targetMonth, count));
+        }
+
+        // 카테고리별 좋아요 통계 부분
+        List<Map<String, Object>> likedCategoryRawData = recipeMapper.selectLikedCategoryStats(userId);
+
+        Map<String, Long> likedCategoryMap = new HashMap<>();
+        for (Map<String, Object> data : likedCategoryRawData) {
+            String categoryName = (String) data.get("categoryName");
+            long count = ((Number) data.get("count")).longValue();
+            likedCategoryMap.put(categoryName, count);
+        }
+
+        Map<String, Integer> likedCategoryPercent = new HashMap<>();
+
+        for (RecipeCategory categoryEnum : RecipeCategory.values()) {
+            long count = likedCategoryMap.getOrDefault(categoryEnum.getKrCategory(), 0L);
+
+            int percent = 0;
+            if (likedCount > 0) {
+                percent = (int) ((count * 100.0) / likedCount);
+            }
+
+            likedCategoryPercent.put(categoryEnum.getKrCategory(), percent);
+        }
+
+        return RecipeDashboardResponse.from(
+                completedCount,
+                likedCount,
+                period,
+                monthlyCompletedStats,
+                likedCategoryPercent
+        );
     }
 }

--- a/src/main/resources/mapper/RecipeMapper.xml
+++ b/src/main/resources/mapper/RecipeMapper.xml
@@ -29,6 +29,7 @@
         <result property="videoUrl" column="video_url"/>
         <result property="duration" column="duration"/>
         <result property="categoryId" column="category_id"/>
+        <result property="categoryName" column="category_name"/>
         <collection property="steps" ofType="com.eateum.eateumbe.recipes.domain.Recipe$RecipeStep">
             <result property="stepNumber" column="step_number"/>
             <result property="stepTitle" column="step_title"/>
@@ -235,6 +236,30 @@
         SELECT COUNT(*)
         FROM liked_recipe
         WHERE user_id = #{userId}
+    </select>
+
+    <!--  월별 완료 레시피 대시보드   -->
+    <select id="selectMonthlyCompletedStats" resultType="map">
+        SELECT
+            MONTH(completed_at) as month,
+            COUNT(*) as count
+        FROM completed_recipe
+        WHERE user_id = #{userId}
+          AND completed_at >= #{startDate}
+        GROUP BY MONTH(completed_at)
+        ORDER BY month ASC
+    </select>
+
+    <!--  좋아요 레시피 비율 대시보드   -->
+    <select id="selectLikedCategoryStats" resultType="map">
+        SELECT
+            c.category_name as categoryName,
+            COUNT(*) as count
+        FROM liked_recipe lr
+        JOIN recipe_video rv ON lr.recipe_video_id = rv.recipe_video_id
+        JOIN category c ON rv.category_id = c.category_id
+        WHERE lr.user_id = #{userId}
+        GROUP BY c.category_name
     </select>
 
 </mapper>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #11
- close : #19, #11
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## ✅ 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 마이페이지 대시보드 상단에 '좋아요' 및 '요리 완료' 전체 누적 갯수 표시
- 최근 6개월간 월별 '요리 완료' 횟수 집계 로직 구현 및 차트 시각화 (데이터 없는 달 0 처리)
- '좋아요'한 레시피의 카테고리별 선호도 비율(%) 계산 로직(각 카테고리*100 / 좋아요 갯수)

## 📸 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->
<img width="1920" height="1206" alt="image" src="https://github.com/user-attachments/assets/43770369-d9bd-47f2-b597-949cd9bcbd39" />


## 🗨️ 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
