### PR TITLE
Feat: 비회원 기본 재료 추가

### DIFF
--- a/src/main/java/com/eateum/eateumbe/fridges/controller/FridgeController.java
+++ b/src/main/java/com/eateum/eateumbe/fridges/controller/FridgeController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -25,24 +26,19 @@ public class FridgeController {
 
     /*
     내 냉장고 조회(무한 스크롤 방식)
-    ResponseEntity에 userId를 통해 재료들을 담는다.
     fridges?userId="userId"로 주소를 받아온다.
-    required = false로 오류는 확인하지 않고 넘어간다.
      */
     @GetMapping
     public ApiResponse<PageResponse<FridgeResponse>> getFridge(
-            @RequestParam(value = "userId", required = false) String userId,
+            @AuthenticationPrincipal String userId,
             //기본 값 "1"로 설정해서 재료가 담긴 페이지 1은 기본으로 둔다.
             @RequestParam(value = "page", defaultValue = "1") int page,
             //1페이지 보여줄 개수 20개
             @RequestParam(value = "size", defaultValue = "20") int size) {
 
-        //테스트용 ID 설정
-        if(userId == null) {
-            userId = "test-user-id";
-        }
+        String safeUserId = resolveUserId(userId);
 
-        PageResponse<FridgeResponse> result = fridgeService.getMyFridgeItems(userId, page, size);
+        PageResponse<FridgeResponse> result = fridgeService.getMyFridgeItems(safeUserId, page, size);
 
         return ApiResponse.success(result);
     }
@@ -64,11 +60,13 @@ public class FridgeController {
      */
     @PostMapping
     public ApiResponse<AddItem> addItem(
-        @RequestBody FridgeRequest request
+            @AuthenticationPrincipal String userId,
+            @RequestBody FridgeRequest request
     ) {
-        String userId = "test-user-id"; //테스트 아이디 임시 추가
 
-        AddItem addedItem = fridgeService.addItem(userId, request);
+        String safeUserId = resolveUserId(userId);
+
+        AddItem addedItem = fridgeService.addItem(safeUserId, request);
 
         return new ApiResponse<>(true, "냉장고에 재료가 추가되었습니다.", addedItem);
     }
@@ -78,12 +76,13 @@ public class FridgeController {
      */
     @DeleteMapping
     public ApiResponse<Void> deleteItem(
+            @AuthenticationPrincipal String userId,
             @RequestParam("itemId") Long itemId
     ) {
 
-        String userId = "test-user-id"; //테스트 아이디 임시 추가
+        String safeUserId = resolveUserId(userId);
 
-        fridgeService.deleteItem(userId, itemId);
+        fridgeService.deleteItem(safeUserId, itemId);
 
         return new ApiResponse<>(true, "재료 삭제 완료", null);
     }
@@ -108,12 +107,22 @@ public class FridgeController {
      */
     @PostMapping("/add-items")
     public ApiResponse<Void> addFridgeItems(
+            @AuthenticationPrincipal String userId,
             @RequestBody List<Long> itemIds) {
 
-        String userId = "test-user-id";
+        String safeUserId = resolveUserId(userId);
 
-        fridgeService.addItems(userId, itemIds);
+        fridgeService.addItems(safeUserId, itemIds);
+
         return new ApiResponse<>(true, "선택한 재료들이 냉장고에 추가되었습니다.", null);
+    }
+
+    //비회원 식별자 변환 로직
+    private String resolveUserId(String userId) {
+        if(userId == null || userId.equals("anonymousUser")) {
+            userId = "guest";
+        }
+        return userId;
     }
 
 

--- a/src/main/java/com/eateum/eateumbe/fridges/service/FridgeService.java
+++ b/src/main/java/com/eateum/eateumbe/fridges/service/FridgeService.java
@@ -1,11 +1,13 @@
 package com.eateum.eateumbe.fridges.service;
 
 import java.util.List;
+
+import org.springframework.web.multipart.MultipartFile;
+
 import com.eateum.eateumbe.fridges.dto.request.FridgeRequest;
 import com.eateum.eateumbe.fridges.dto.response.FridgeResponse;
 import com.eateum.eateumbe.fridges.dto.response.FridgeResponse.AddItem;
 import com.eateum.eateumbe.global.common.PageResponse;
-import org.springframework.web.multipart.MultipartFile;
 
 
 public interface FridgeService {

--- a/src/main/java/com/eateum/eateumbe/fridges/service/FridgeServiceImpl.java
+++ b/src/main/java/com/eateum/eateumbe/fridges/service/FridgeServiceImpl.java
@@ -2,7 +2,6 @@ package com.eateum.eateumbe.fridges.service;
 
 import java.util.List;
 
-import com.eateum.eateumbe.global.common.PageResponse;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
@@ -12,6 +11,7 @@ import com.eateum.eateumbe.fridges.dto.request.FridgeRequest;
 import com.eateum.eateumbe.fridges.dto.response.FridgeResponse;
 import com.eateum.eateumbe.fridges.dto.response.FridgeResponse.AddItem;
 import com.eateum.eateumbe.fridges.repository.FridgeMapper;
+import com.eateum.eateumbe.global.common.PageResponse;
 import org.springframework.web.multipart.MultipartFile;
 
 
@@ -25,6 +25,17 @@ public class FridgeServiceImpl implements FridgeService {
     //내 냉장고 재료 조회
     @Override
     public PageResponse<FridgeResponse> getMyFridgeItems(String userId, int page, int size) {
+
+        //비회원인 경우: DB 조회 없이 고정된 7가지 재료 반환
+        if("guest".equalsIgnoreCase(userId)){
+            List<String> guestItemNames = List.of("돼지고기", "스팸", "달걀", "김치", "라면", "양파", "파");
+
+            List<FridgeResponse> guestList = fridgeMapper.selectItemsByNames(guestItemNames);
+
+            return PageResponse.of(guestList, guestList.size(), page, size);
+        }
+
+        //회원인 경우
         //offset을 설정하기 위함 페이지가 넘어가면 그 앞에 개수를 제외하고 순서대로 재료를 가지고 온다. (무한 스크롤 진행이라도 몇 개인지 기준이 필요함)
         int offset = (page - 1) * size;
         //Mapper에게 데이터 조회를 요청시킨다. (limit, offset을 전달)
@@ -45,6 +56,12 @@ public class FridgeServiceImpl implements FridgeService {
     @Override
     @Transactional
     public AddItem addItem(String userId, FridgeRequest request) {
+
+        //비회원은 재료 추가 불가
+        if("guest".equalsIgnoreCase(userId)){
+            throw new IllegalArgumentException("재료를 저장하려면 로그인이 필요합니다.");
+        }
+
         fridgeMapper.addFridgeItem(userId, request.getItemId());
 
         return fridgeMapper.selectItemDetail(request.getItemId());
@@ -54,6 +71,11 @@ public class FridgeServiceImpl implements FridgeService {
     @Override
     @Transactional
     public void deleteItem(String userId, Long itemId) {
+        //비회원은 재료 추가 불가
+        if("guest".equalsIgnoreCase(userId)){
+            throw new IllegalArgumentException("재료를 삭제하려면 로그인이 필요합니다.");
+        }
+
         fridgeMapper.deleteItem(userId, itemId);
     }
 
@@ -72,7 +94,12 @@ public class FridgeServiceImpl implements FridgeService {
     @Override
     @Transactional
     public void addItems(String userId, List<Long> itemIds) {
-        if(itemIds != null || !itemIds.isEmpty()){
+        //비회원은 재료 추가 불가
+        if("guest".equalsIgnoreCase(userId)){
+            throw new IllegalArgumentException("재료를 저장하려면 로그인이 필요합니다.");
+        }
+
+        if(itemIds != null && !itemIds.isEmpty()){
             fridgeMapper.addFridgeItems(userId, itemIds);
         }
     }

--- a/src/main/java/com/eateum/eateumbe/fridges/service/GeminiService.java
+++ b/src/main/java/com/eateum/eateumbe/fridges/service/GeminiService.java
@@ -1,22 +1,19 @@
 package com.eateum.eateumbe.fridges.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URI;
+import java.util.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
-import java.io.IOException;
-import java.net.URI;
-import java.util.*;
 
 @Slf4j
 @Service


### PR DESCRIPTION
테스트 ID 삭제 후, JWT 토큰 로그인을 통한 재료 추가 및 비회원 게스트 조회 재료 성공

## #️⃣ 연관된 이슈
- #21 
- close : #21, #50 


## ✅ 작업 내용
- 내용 1: 비회원(게스트) 재료 7가지 기본 재료 추가
- 내용 2: JWT 토큰을 사용하여 테스트 ID 삭제 후 로그인 확인하여 테스트 진행

## 📸 스크린샷 
<img width="1419" height="740" alt="스크린샷 2025-12-18 030602" src="https://github.com/user-attachments/assets/78bde7d9-0fc4-4399-9832-f73a14a4653c" />
<img width="1372" height="806" alt="스크린샷 2025-12-18 030639" src="https://github.com/user-attachments/assets/b58699d3-0e56-4496-add0-c49fcdfc11f7" />
<img width="1318" height="942" alt="스크린샷 2025-12-18 030648" src="https://github.com/user-attachments/assets/429ea95d-63b9-41b7-a8ce-75e8d3d8842d" />


## 🗨️ 참고 사항
비회원 이름은 이제 guest로 통일
JWT 토큰을 통해 테스트 해보려면 로그에 찍고 암호화 된 비번을 알아야함
