### PR TITLE
Refactor: SecurityExceptionFilter 응답 통일 리팩토링

### DIFF
--- a/src/main/java/com/eateum/eateumbe/global/security/SecurityExceptionFilter.java
+++ b/src/main/java/com/eateum/eateumbe/global/security/SecurityExceptionFilter.java
@@ -1,5 +1,6 @@
 package com.eateum.eateumbe.global.security;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Map;
 
 @Component
 public class SecurityExceptionFilter extends OncePerRequestFilter {
@@ -23,13 +25,19 @@ public class SecurityExceptionFilter extends OncePerRequestFilter {
         try {
             filterChain.doFilter(request, response);
         } catch (JwtException e) {
+            //동일한 예외 포맷으로 응답
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.setContentType("application/json");
-            response.getWriter().write(
-                """
-                       {"message": "TOKEN_ERROR"}
-                   """
+            response.setContentType("application/json;charset=UTF-8");
+
+            ObjectMapper mapper = new ObjectMapper();
+
+            Map<String, Object> body = Map.of(
+                    "success", false,
+                    "code", "TOKEN_ERROR",
+                    "message", "엑세스 토큰이 만료되었습니다."
             );
+
+            response.getWriter().write(mapper.writeValueAsString(body));
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #61
- close : #61
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## ✅ 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- SecurityExceptionFilter 응답을 ApiException 응답 구조와 통일시킴

## 📸 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

## 🗨️ 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
