### PR TITLE
Feat: 상세 페이지 조회시, 조회수 증가

### DIFF
--- a/src/main/java/com/eateum/eateumbe/global/util/ClientIpUtils.java
+++ b/src/main/java/com/eateum/eateumbe/global/util/ClientIpUtils.java
@@ -1,0 +1,28 @@
+package com.eateum.eateumbe.global.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+public class ClientIpUtils {
+
+    private ClientIpUtils() {}
+
+    // 현재 요청하는 클라이언트의 ip 주소 반환하는 로직
+    public static String getRemoteIP() {
+        HttpServletRequest req = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+        String ip = req.getHeader("X-Forwarded-For");
+
+        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+            ip = req.getRemoteAddr();
+        }
+
+        // X-Forwarded-For는 여러 IP가 올 수 있음 즉, 첫 번째가 실제 IP
+        if (ip != null && ip.contains(",")) {
+            ip = ip.split(",")[0].trim();
+        }
+
+        return ip;
+    }
+}

--- a/src/main/java/com/eateum/eateumbe/memo/controller/MemoController.java
+++ b/src/main/java/com/eateum/eateumbe/memo/controller/MemoController.java
@@ -5,6 +5,7 @@ import com.eateum.eateumbe.global.common.BaseController;
 import com.eateum.eateumbe.memo.dto.request.MemoRequest;
 import com.eateum.eateumbe.memo.dto.response.MemoResponse;
 import com.eateum.eateumbe.memo.service.MemoService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -18,6 +19,7 @@ public class MemoController extends BaseController {
 
     private final MemoService memoService;
 
+    @Operation(summary = "메모 조회")
     @GetMapping
     public ApiResponse<List<MemoResponse>> getMemosByRecipe(
         @AuthenticationPrincipal String userId,
@@ -29,6 +31,7 @@ public class MemoController extends BaseController {
         return ApiResponse.success(response);
     }
 
+    @Operation(summary = "메모 등록")
     @PostMapping
     public ApiResponse<MemoResponse> createMemo(
         @AuthenticationPrincipal String userId,
@@ -39,6 +42,7 @@ public class MemoController extends BaseController {
         return ApiResponse.success(response);
     }
 
+    @Operation(summary = "메모 삭제")
     @DeleteMapping("/{memo_id}")
     public ApiResponse<Void> deleteMemo(
         @AuthenticationPrincipal String userId,
@@ -48,5 +52,4 @@ public class MemoController extends BaseController {
         memoService.deleteMemo(memoId, userId);
         return ApiResponse.success(null);
     }
-
 }

--- a/src/main/java/com/eateum/eateumbe/recipes/controller/RecipeController.java
+++ b/src/main/java/com/eateum/eateumbe/recipes/controller/RecipeController.java
@@ -9,6 +9,7 @@ import com.eateum.eateumbe.recipes.dto.response.RecipeDashboardResponse;
 import com.eateum.eateumbe.recipes.dto.response.RecipeDetailResponse;
 import com.eateum.eateumbe.recipes.dto.response.RecipeResponse;
 import com.eateum.eateumbe.recipes.service.RecipeService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -23,6 +24,7 @@ public class RecipeController extends BaseController {
 
     private final RecipeService recipeService;
 
+    @Operation(summary = "AI 추천 레시피")
     @PostMapping("/recommend/ai")
     public ApiResponse<List<RecipeResponse.Recommend>> recommendAi(@AuthenticationPrincipal String userId, @RequestBody RecipeRequest.Recommend request) {
 
@@ -33,19 +35,21 @@ public class RecipeController extends BaseController {
         return ApiResponse.success(results);
     }
 
+    @Operation(summary = "15분 컷 레시피")
     @GetMapping("/recommend/speed")
     public ApiResponse<List<RecipeResponse.Recommend>> recommendSpeed() {
         List<RecipeResponse.Recommend> results = recipeService.recommendSpeedRecipes();
         return ApiResponse.success(results);
     }
 
-
+    @Operation(summary = "지금 뜨고 있는 레시피")
     @GetMapping("/recommend/popular")
     public ApiResponse<List<RecipeResponse.Recommend>> recommendPopular() {
         List<RecipeResponse.Recommend> results = recipeService.recommendPopularRecipes();
         return ApiResponse.success(results);
     }
 
+    @Operation(summary = "레시피 상세 조회")
     @GetMapping("/{recipe_video_id}/detail")
     public ApiResponse<RecipeDetailResponse> getRecipeDetail(
         @AuthenticationPrincipal String userId,
@@ -63,6 +67,7 @@ public class RecipeController extends BaseController {
         return ApiResponse.success(response);
     }
 
+    @Operation(summary = "마이 페이지")
     @GetMapping("/my")
     public ApiResponse<PageResponse<RecipeResponse.Status>> getStatusRecipes(
             @AuthenticationPrincipal String userId,
@@ -75,12 +80,14 @@ public class RecipeController extends BaseController {
         return ApiResponse.success(result);
     }
 
+    @Operation(summary = "마이페이지 대시보드")
     @GetMapping("my/dashboard")
     public ApiResponse<RecipeDashboardResponse> getDashboardRecipes(@AuthenticationPrincipal String userId) {
         RecipeDashboardResponse response = recipeService.getRecipeDashboard(userId);
         return ApiResponse.success(response);
     }
 
+    @Operation(summary = "좋아요 버튼")
     @PostMapping("{recipe_video_id}/like")
     public ApiResponse<Void> buttonLike(
             @AuthenticationPrincipal String userId,
@@ -97,6 +104,7 @@ public class RecipeController extends BaseController {
         return ApiResponse.success(null);
     }
 
+    @Operation(summary = "완성 버튼")
     @PostMapping("{recipe_video_id}/complete")
     public ApiResponse<Void> buttonComplete(
             @AuthenticationPrincipal String userId,

--- a/src/main/java/com/eateum/eateumbe/recipes/repository/RecipeMapper.java
+++ b/src/main/java/com/eateum/eateumbe/recipes/repository/RecipeMapper.java
@@ -64,5 +64,7 @@ public interface RecipeMapper {
     // 좋아요 카테고리 비율 통계
     List<Map<String, Object>> selectLikedCategoryStats(@Param("userId") String userId);
 
+    // 시스템 내부 조회수 증가
+    void updateUserViewCount(@Param("recipeVideoId") Long recipeVideoId);
 }
 

--- a/src/main/java/com/eateum/eateumbe/recipes/service/RecipeServiceImpl.java
+++ b/src/main/java/com/eateum/eateumbe/recipes/service/RecipeServiceImpl.java
@@ -4,6 +4,7 @@ import com.eateum.eateumbe.fridges.repository.FridgeMapper;
 import com.eateum.eateumbe.fridges.service.FridgeService;
 import com.eateum.eateumbe.global.common.PageResponse;
 import com.eateum.eateumbe.global.constant.RecipeCategory;
+import com.eateum.eateumbe.global.util.ClientIpUtils;
 import com.eateum.eateumbe.memo.dto.response.MemoResponse;
 import com.eateum.eateumbe.memo.service.MemoService;
 import com.eateum.eateumbe.recipes.domain.Recipe;
@@ -13,16 +14,18 @@ import com.eateum.eateumbe.recipes.dto.response.RecipeDetailResponse;
 import com.eateum.eateumbe.recipes.dto.response.RecipeResponse;
 import com.eateum.eateumbe.recipes.repository.RecipeMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class RecipeServiceImpl implements RecipeService {
 
     private final RecipeMapper recipeMapper;
@@ -30,6 +33,8 @@ public class RecipeServiceImpl implements RecipeService {
     private final FridgeService fridgeService;
     private final RagService ragService;
     private final MemoService memoService;
+
+    private final RedisTemplate<String, String> redisTemplate;
 
 
     @Override
@@ -43,7 +48,6 @@ public class RecipeServiceImpl implements RecipeService {
         }
 
         // 2) 재료 선택이 없는 경우 (비회원/ 첫 가입자)
-
         else {
             if(!"guest".equalsIgnoreCase(userId)){
                 items = fridgeMapper.selectItemNamesByUserId(userId);
@@ -90,6 +94,25 @@ public class RecipeServiceImpl implements RecipeService {
 
     @Override
     public RecipeDetailResponse getRecipeDetail(String userId, Long recipeVideoId, Boolean includeMemo) {
+
+        // 조회수 관련 로직 부분
+        // 로그인 유저는 ID, 비회원은 IP
+        String viewerId = userId;
+        if ("guest".equalsIgnoreCase(userId)) {
+            viewerId = ClientIpUtils.getRemoteIP();
+        }
+
+        // redis 키 생성
+        String redisKey = "view:recipe:" + recipeVideoId + ":user:" + viewerId;
+
+        // 키(=24시간 전에 방문한적이) 없을시에만, 조회수 증가
+        if (redisTemplate.opsForValue().get(redisKey) == null) {
+
+            recipeMapper.updateUserViewCount(recipeVideoId);
+
+            redisTemplate.opsForValue().set(redisKey, "1", Duration.ofHours(24));
+        }
+
 
         Recipe recipe = recipeMapper.selectRecipeDetail(recipeVideoId, userId);
         if (recipe == null) {

--- a/src/main/resources/mapper/RecipeMapper.xml
+++ b/src/main/resources/mapper/RecipeMapper.xml
@@ -285,4 +285,11 @@
         GROUP BY c.category_name
     </select>
 
+    <!-- 상세 페이지 조회시, 조회수 증가   -->
+    <update id="updateUserViewCount">
+        UPDATE recipe_video
+        SET user_view_count = user_view_count + 1
+        WHERE recipe_video_id = #{recipeVideoId}
+    </update>
+
 </mapper>


### PR DESCRIPTION

## #️⃣ 연관된 이슈
- #11 #15
- close : #70
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## ✅ 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- Redis를 도입하여 24시간 중복 조회 방지(IP/User 식별) 및 어뷰징 방지 로직 적용
-  유저 조회수(user_view_count) 분리 저장 구현

## 🗨️ 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
내부 조회수(user_view_count) 집계 로직은 구현되었으나, 현재 UI상 노출 위치가 기획되지 않아 화면에는 표시되지 않고 있습니다. 
이 부분에 대한 추후 논의가 필요합니다.
