### PR TITLE
Feat: 아이디/비밀번호 찾기 & 이메일 중복 검사 API 분리

### DIFF
--- a/src/main/java/com/eateum/eateumbe/global/config/SecurityConfig.java
+++ b/src/main/java/com/eateum/eateumbe/global/config/SecurityConfig.java
@@ -84,7 +84,13 @@ public class SecurityConfig {
                             "/user/signup",
                             "/user/login",
                             "/user/reissue",
-                            "/user/logout"
+                            "/user/logout",
+                            "/user/find-id",
+                            "/user/find-password"
+                    ).permitAll()
+
+                    .requestMatchers(HttpMethod.GET,
+                            "user/check-email"
                     ).permitAll()
 
                     //그 외 user는 전부 인증 필요

--- a/src/main/java/com/eateum/eateumbe/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/eateum/eateumbe/global/error/GlobalExceptionHandler.java
@@ -3,6 +3,8 @@ package com.eateum.eateumbe.global.error;
 import com.eateum.eateumbe.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Hidden;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -25,6 +27,25 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(e.getStatus())
                 .body(ApiResponse.fail(e.getMessage()));
+    }
+
+    //DB UNIQUE 제약 조건 위반
+    @ExceptionHandler(DuplicateKeyException.class)
+    public ResponseEntity<ApiResponse<Void>> handleDuplicateKeyException(DuplicateKeyException e) {
+        log.warn("DuplicateKeyException 발생", e);
+        String message = "이미 사용 중인 값입니다.";
+
+        if(e.getMessage() != null) {
+            if(e.getMessage().contains("uk_users_email")) {
+                message = "이미 사용 중인 이메일입니다.";
+            } else if(e.getMessage().contains("uk_users_phone")) {
+                message = "이미 사용 중인 전화번호입니다.";
+            }
+        }
+
+        return  ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(ApiResponse.fail(message));
     }
 
     //파일 업로드 예외

--- a/src/main/java/com/eateum/eateumbe/global/security/JwtVerificationFilter.java
+++ b/src/main/java/com/eateum/eateumbe/global/security/JwtVerificationFilter.java
@@ -102,6 +102,9 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
                 || path.startsWith("/user/signup")
                 || path.startsWith("/user/reissue")
                 || path.startsWith("/user/logout")
+                || path.startsWith("/user/find-id")
+                || path.startsWith("/user/find-password")
+                || path.startsWith("/user/check-email")
                 || path.startsWith("/v3/api-docs")
                 || path.startsWith("/swagger-ui");
     }

--- a/src/main/java/com/eateum/eateumbe/user/controller/UserController.java
+++ b/src/main/java/com/eateum/eateumbe/user/controller/UserController.java
@@ -1,7 +1,6 @@
 package com.eateum.eateumbe.user.controller;
 
 import com.eateum.eateumbe.global.common.ApiResponse;
-import com.eateum.eateumbe.global.error.ApiException;
 import com.eateum.eateumbe.user.dto.request.*;
 import com.eateum.eateumbe.user.dto.response.FindIdResponse;
 import com.eateum.eateumbe.user.dto.response.LoginResponse;

--- a/src/main/java/com/eateum/eateumbe/user/controller/UserController.java
+++ b/src/main/java/com/eateum/eateumbe/user/controller/UserController.java
@@ -3,7 +3,9 @@ package com.eateum.eateumbe.user.controller;
 import com.eateum.eateumbe.global.common.ApiResponse;
 import com.eateum.eateumbe.global.error.ApiException;
 import com.eateum.eateumbe.user.dto.request.*;
+import com.eateum.eateumbe.user.dto.response.FindIdResponse;
 import com.eateum.eateumbe.user.dto.response.LoginResponse;
+import com.eateum.eateumbe.user.dto.response.PasswordResetResponse;
 import com.eateum.eateumbe.user.dto.response.UserInfoResponse;
 import com.eateum.eateumbe.user.service.auth.AuthService;
 import com.eateum.eateumbe.user.service.account.UserAccountService;
@@ -27,6 +29,9 @@ public class UserController {
     private final UserProfileService  userProfileService;
     private final UserAccountService userAccountService;
 
+    /**
+     * 로그인
+     */
     @PostMapping("/login")
     public ApiResponse<LoginResponse> login(
             @RequestBody LoginRequest request,
@@ -35,6 +40,9 @@ public class UserController {
         return ApiResponse.success(loginResponse);
     }
 
+    /**
+     * 엑세스 토큰 재발급
+     */
     @PostMapping("/reissue")
     public ApiResponse<LoginResponse> reissue(
             @CookieValue(value = "refreshToken", required = false) String refreshToken,
@@ -43,6 +51,9 @@ public class UserController {
         return ApiResponse.success(loginResponse);
     }
 
+    /**
+     * 로그아웃
+     */
     @PostMapping("/logout")
     public ApiResponse<Void> logout(
             @CookieValue(value = "refreshToken", required = false) String refreshToken,
@@ -51,11 +62,17 @@ public class UserController {
         return ApiResponse.success(null);
     }
 
+    /**
+     * 프로필 조회
+     */
     @GetMapping("/info")
     public ApiResponse<UserInfoResponse> getUserInfo(@AuthenticationPrincipal String userId) {
         return ApiResponse.success(userProfileService.getUserInfo(userId));
     }
 
+    /**
+     * 회원가입
+     */
     @PostMapping(value = "/signup", consumes = MediaType.MULTIPART_FORM_DATA_VALUE) //multipart/form-data 요청만 받음
     public ApiResponse<Void> signup(@Valid @RequestPart("signup") SignupRequest signupRequest, //part단위로 나누어서 JSON 파트를 받음
                                     @RequestPart(value = "profileImage", required = false) MultipartFile profileImage){ //파일 파트를 받음
@@ -63,6 +80,9 @@ public class UserController {
         return ApiResponse.success(null);
     }
 
+    /**
+     * 프로필 수정
+     */
     @PatchMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<Void> updateInfo(@AuthenticationPrincipal String userId,
                                         @RequestPart("update") UpdateInfoRequest updateInfoRequest,
@@ -96,7 +116,7 @@ public class UserController {
     /**
      * 비밀번호 재확인 (프로필 진입 전)
      */
-    @PostMapping("/password-check")
+    @PostMapping("/check-password")
     public ApiResponse<Void> passwordCheck(@RequestBody @Valid PasswordCheckRequest passwordCheckRequest) {
         userAccountService.checkPassword(passwordCheckRequest.getPassword());
         return ApiResponse.success(null);
@@ -108,6 +128,33 @@ public class UserController {
     @PatchMapping("/withdraw")
     public ApiResponse<Void> withdraw(@AuthenticationPrincipal String userId) {
         userAccountService.withdraw(userId);
+        return ApiResponse.success(null);
+    }
+
+    /**
+     * 아이디 찾기
+     */
+    @PostMapping("/find-id")
+    public ApiResponse<FindIdResponse> findId(@RequestBody @Valid FindIdRequest findIdRequest) {
+        FindIdResponse findIdResponse = userAccountService.findId(findIdRequest);
+        return ApiResponse.success(findIdResponse);
+    }
+
+    /**
+     * 비밀번호 찾기 (=재설정)
+     */
+    @PostMapping("/find-password")
+    public ApiResponse<PasswordResetResponse> findPassword(@RequestBody @Valid PasswordResetRequest passwordResetRequest) {
+        PasswordResetResponse passwordResetResponse = userAccountService.resetPassword(passwordResetRequest);
+        return ApiResponse.success(passwordResetResponse);
+    }
+
+    /**
+     * 이메일 중복 확인
+     */
+    @GetMapping("check-email")
+    public ApiResponse<Void> checkEmail(@RequestParam String email) {
+        userAccountService.checkEmailDuplicate(email);
         return ApiResponse.success(null);
     }
 

--- a/src/main/java/com/eateum/eateumbe/user/domain/User.java
+++ b/src/main/java/com/eateum/eateumbe/user/domain/User.java
@@ -15,6 +15,7 @@ public class User {
     private String email;
     private String password;
     private String name;
+    private String phone;
     private String role; //USER
     private int isActive; //1 = 활성, 0 = 비활성
     private String profileImage;

--- a/src/main/java/com/eateum/eateumbe/user/dto/request/FindIdRequest.java
+++ b/src/main/java/com/eateum/eateumbe/user/dto/request/FindIdRequest.java
@@ -1,0 +1,14 @@
+package com.eateum.eateumbe.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class FindIdRequest {
+
+    @NotBlank
+    private String name;
+    @NotBlank
+    private String phone;
+
+}

--- a/src/main/java/com/eateum/eateumbe/user/dto/request/PasswordResetRequest.java
+++ b/src/main/java/com/eateum/eateumbe/user/dto/request/PasswordResetRequest.java
@@ -1,0 +1,20 @@
+package com.eateum.eateumbe.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class PasswordResetRequest {
+
+    @NotBlank
+    private String email;
+    @NotBlank
+    private String name;
+    @NotBlank
+    private String phone;
+    @NotBlank
+    private String newPassword;
+    @NotBlank
+    private String confirmPassword;
+
+}

--- a/src/main/java/com/eateum/eateumbe/user/dto/request/SignupRequest.java
+++ b/src/main/java/com/eateum/eateumbe/user/dto/request/SignupRequest.java
@@ -12,6 +12,7 @@ public class SignupRequest {
     private String email;
     private String password;
     private String name;
+    private String phone;
 //    private String profileImage; //프로필이미지 파일은 MultipartFile로만 처리
 
 }

--- a/src/main/java/com/eateum/eateumbe/user/dto/request/UpdateInfoRequest.java
+++ b/src/main/java/com/eateum/eateumbe/user/dto/request/UpdateInfoRequest.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 public class UpdateInfoRequest {
 
     private String name;
+    private String phone;
     //    private String profileImage; //프로필이미지 파일은 MultipartFile로만 처리
 
 }

--- a/src/main/java/com/eateum/eateumbe/user/dto/response/FindIdResponse.java
+++ b/src/main/java/com/eateum/eateumbe/user/dto/response/FindIdResponse.java
@@ -1,0 +1,13 @@
+package com.eateum.eateumbe.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FindIdResponse {
+
+    private String email;
+    private boolean active;
+
+}

--- a/src/main/java/com/eateum/eateumbe/user/dto/response/PasswordResetResponse.java
+++ b/src/main/java/com/eateum/eateumbe/user/dto/response/PasswordResetResponse.java
@@ -1,0 +1,13 @@
+package com.eateum.eateumbe.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PasswordResetResponse {
+
+    private String message;
+    private boolean reactivated;
+
+}

--- a/src/main/java/com/eateum/eateumbe/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/eateum/eateumbe/user/dto/response/UserInfoResponse.java
@@ -10,5 +10,6 @@ import lombok.Getter;
 public class UserInfoResponse {
     private String email;
     private String name;
+    private String phone;
     private String profileImage;
 }

--- a/src/main/java/com/eateum/eateumbe/user/repository/UserMapper.java
+++ b/src/main/java/com/eateum/eateumbe/user/repository/UserMapper.java
@@ -16,6 +16,9 @@ public interface UserMapper {
     //이메일 중복 확인
     int existsByEmail(String email);
 
+    //전화번호 중복 확인
+    int existsByPhone(String phone);
+
     //회원가입
     void insertUser(User user);
 
@@ -30,4 +33,16 @@ public interface UserMapper {
 
     //탈퇴
     int withdraw(String userId);
+
+    //아이디 찾기
+    User findIdByNameAndPhone(@Param("name") String name, @Param("phone") String phone);
+
+    //비밀번호 찾기
+    void resetPassword(@Param("userId") String userId, @Param("password") String password);
+
+    //비밀번호 찾기 시 정보 조회
+    User findByEmailAll(@Param("email") String email);
+
+    //재활성화
+    int reActive(@Param("email") String email, @Param("name")String name, @Param("phone") String phone);
 }

--- a/src/main/java/com/eateum/eateumbe/user/service/account/UserAccountService.java
+++ b/src/main/java/com/eateum/eateumbe/user/service/account/UserAccountService.java
@@ -1,8 +1,8 @@
 package com.eateum.eateumbe.user.service.account;
 
-import com.eateum.eateumbe.user.dto.request.PasswordChangeRequest;
-import com.eateum.eateumbe.user.dto.request.SignupRequest;
-import jakarta.validation.constraints.NotBlank;
+import com.eateum.eateumbe.user.dto.request.*;
+import com.eateum.eateumbe.user.dto.response.FindIdResponse;
+import com.eateum.eateumbe.user.dto.response.PasswordResetResponse;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface UserAccountService {
@@ -18,4 +18,13 @@ public interface UserAccountService {
 
     //탈퇴
     void withdraw(String userId);
+
+    //아이디 찾기
+    FindIdResponse findId(FindIdRequest findIdRequest);
+
+    //비밀번호 재설정
+    PasswordResetResponse resetPassword(PasswordResetRequest passwordResetRequest);
+
+    //이메일 중복 확인
+    void checkEmailDuplicate(String email);
 }

--- a/src/main/java/com/eateum/eateumbe/user/service/account/UserAccountServiceImpl.java
+++ b/src/main/java/com/eateum/eateumbe/user/service/account/UserAccountServiceImpl.java
@@ -3,8 +3,9 @@ package com.eateum.eateumbe.user.service.account;
 import com.eateum.eateumbe.global.error.ApiException;
 import com.eateum.eateumbe.global.redis.RefreshTokenService;
 import com.eateum.eateumbe.user.domain.User;
-import com.eateum.eateumbe.user.dto.request.PasswordChangeRequest;
-import com.eateum.eateumbe.user.dto.request.SignupRequest;
+import com.eateum.eateumbe.user.dto.request.*;
+import com.eateum.eateumbe.user.dto.response.FindIdResponse;
+import com.eateum.eateumbe.user.dto.response.PasswordResetResponse;
 import com.eateum.eateumbe.user.repository.UserMapper;
 import com.eateum.eateumbe.user.service.image.ProfileImageService;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +43,11 @@ public class UserAccountServiceImpl implements UserAccountService {
             throw new ApiException(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다.");
         }
 
+        //전화번호 중복 체크
+        if(userMapper.existsByPhone(signupRequest.getPhone()) > 0) {
+            throw new ApiException(HttpStatus.CONFLICT, "입력하신 전화번호로 이미 가입된 계정이 있습니다. 아이디 찾기를 통해 확인해주세요.");
+        }
+
         //프로필 이미지 업로드
         String imageUrl = null;
         if(profileImage != null && !profileImage.isEmpty()) {
@@ -54,6 +60,7 @@ public class UserAccountServiceImpl implements UserAccountService {
                 .email(signupRequest.getEmail())
                 .password(passwordEncoder.encode(signupRequest.getPassword()))
                 .name(signupRequest.getName())
+                .phone(signupRequest.getPhone())
                 .profileImage(imageUrl)
                 .build();
 
@@ -129,6 +136,66 @@ public class UserAccountServiceImpl implements UserAccountService {
         refreshTokenService.delete(userId);
     }
 
+    /**
+     * 아이디(=이메일) 찾기
+     */
+    @Override
+    public FindIdResponse findId(FindIdRequest findIdRequest) {
 
+        User user = userMapper.findIdByNameAndPhone(findIdRequest.getName(), findIdRequest.getPhone());
 
+        //아예 존재하지 않는다면
+        if (user == null) {
+            throw new ApiException(HttpStatus.UNAUTHORIZED, "입력한 정보와 일치하는 사용자를 찾을 수 없습니다.");
+        }
+
+        //존재하는 사용자라면
+        return new FindIdResponse(user.getEmail(), user.getIsActive() == 1);
+    }
+
+    /**
+     * 비밀번호 재설정
+     */
+    @Override
+    public PasswordResetResponse resetPassword(PasswordResetRequest passwordResetRequest) {
+        
+        User user = userMapper.findByEmailAll(passwordResetRequest.getEmail());
+        if (user == null) {
+            throw new ApiException(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다.");
+        }
+        
+        //본인 검증
+        if (!user.getName().equals(passwordResetRequest.getName())
+                || !user.getPhone().equals(passwordResetRequest.getPhone())) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "사용자 정보가 일치하지 않습니다.");
+        }
+
+        //비밀번호 확인
+        if(!passwordResetRequest.getNewPassword().equals(passwordResetRequest.getConfirmPassword())) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.");
+        }
+        
+        //비밀번호 변경
+        userMapper.resetPassword(user.getUserId(), passwordEncoder.encode(passwordResetRequest.getNewPassword()));
+
+        //탈퇴 사용자면 재활성화
+        if(user.getIsActive() == 0) {
+            userMapper.reActive(user.getEmail(), user.getName(), user.getPhone());
+            return new PasswordResetResponse(
+                    "탈퇴한 계정이 재활성화되었습니다. 새 비밀번호로 로그인해주세요.",
+                    true);
+        }
+
+        return new PasswordResetResponse(
+                "비밀번호가 변경되었습니다. 다시 로그인해주세요.",
+                false
+        );
+    }
+
+    @Override
+    public void checkEmailDuplicate(String email) {
+        if(userMapper.existsByEmail(email) > 0) {
+            throw new ApiException(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다.");
+        }
+    }
 }

--- a/src/main/java/com/eateum/eateumbe/user/service/profile/UserProfileServiceImpl.java
+++ b/src/main/java/com/eateum/eateumbe/user/service/profile/UserProfileServiceImpl.java
@@ -1,5 +1,6 @@
 package com.eateum.eateumbe.user.service.profile;
 
+import com.eateum.eateumbe.global.error.ApiException;
 import com.eateum.eateumbe.user.domain.User;
 import com.eateum.eateumbe.user.dto.request.UpdateInfoRequest;
 import com.eateum.eateumbe.user.dto.response.UserInfoResponse;
@@ -8,6 +9,7 @@ import com.eateum.eateumbe.user.service.image.ProfileImageService;
 import com.eateum.eateumbe.user.service.reader.UserReader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -34,6 +36,7 @@ public class UserProfileServiceImpl implements UserProfileService {
         return UserInfoResponse.builder()
                 .email(user.getEmail())
                 .name(user.getName())
+                .phone(user.getPhone())
                 .profileImage(profileImageService.resolve(user.getProfileImage())) //프로필 이미지가 있는지?
                 .build();
     }
@@ -48,6 +51,17 @@ public class UserProfileServiceImpl implements UserProfileService {
         //이름 수정
         if(updateInfoRequest.getName() != null && !updateInfoRequest.getName().isBlank()) {
             user.setName(updateInfoRequest.getName());
+        }
+
+        //전화번호 수정
+        if(updateInfoRequest.getPhone() != null && !updateInfoRequest.getPhone().isBlank()) {
+
+            //기존과 다를 때만 중복 검사
+            if(!updateInfoRequest.getPhone().equals(user.getPhone()) && userMapper.existsByPhone(updateInfoRequest.getPhone()) > 0) {
+                throw new ApiException(HttpStatus.CONFLICT, "이미 사용 중인 전화번호입니다. 다시 확인해 주세요.");
+            }
+
+            user.setPhone(updateInfoRequest.getPhone());
         }
 
         //프로필 이미지 수정

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -11,9 +11,16 @@
         WHERE email = #{email} AND is_active = 1
     </select>
 
+    <!--  비밀번호 찾기 시 활성 조건 없이 사용자 조회 (계정관리용) -->
+    <select id="findByEmailAll" resultType="User">
+        SELECT user_id, name, phone, is_active
+        FROM users
+        WHERE email = #{email}
+    </select>
+
     <!--  프로필 조회  -->
     <select id="findByUserId" resultType="User">
-        SELECT user_id, email, name, profile_image
+        SELECT user_id, email, name, phone, profile_image
         FROM users
         WHERE user_id = #{userId} AND is_active = 1
     </select>
@@ -22,13 +29,20 @@
     <select id="existsByEmail" resultType="int">
         SELECT COUNT(*)
         FROM users
-        WHERE email = #{email}
+        WHERE email = #{email};
+    </select>
+
+    <!--  전화번호 중복 확인  -->
+    <select id="existsByPhone" resultType="int">
+        SELECT COUNT(*)
+        FROM users
+        WHERE phone = #{phone};
     </select>
 
     <!--  회원가입  -->
     <insert id="insertUser">
-        INSERT INTO users(user_id, email, password, name, profile_image)
-        VALUES (#{userId}, #{email}, #{password}, #{name}, #{profileImage})
+        INSERT INTO users(user_id, email, password, name, phone, profile_image)
+        VALUES (#{userId}, #{email}, #{password}, #{name}, #{phone}, #{profileImage})
     </insert>
 
     <!--  프로필 수정  -->
@@ -38,6 +52,10 @@
             <!--  이름 변경  -->
             <if test="name != null">
                 name = #{name},
+            </if>
+            <!--  전화번호 변경  -->
+            <if test="phone != null">
+                phone = #{phone},
             </if>
             <!--  프로필 이미지 변경, NULL이어도 변경! -->
             profile_image = #{profileImage},
@@ -60,11 +78,33 @@
         WHERE user_id = #{userId} AND is_active = 1
     </select>
 
-    <!-- 탈퇴  -->
+    <!--  탈퇴  -->
     <update id="withdraw">
         UPDATE users
         SET is_active = 0,
             updated_at = NOW()
         WHERE user_id = #{userId} AND is_active = 1
+    </update>
+
+    <!--  아이디 찾기  -->
+    <select id="findIdByNameAndPhone" resultType="User">
+        SELECT email, is_active
+        FROM users
+        WHERE name = #{name} AND phone = #{phone}
+    </select>
+
+    <!--  비밀번호 재설정  -->
+    <update id="resetPassword">
+        UPDATE users
+        SET password = #{password}
+        WHERE user_id = #{userId}
+    </update>
+    
+    <!--  재활성화  -->
+    <update id="reActive">
+        UPDATE users
+        SET is_active = 1,
+            updated_at = NOW()
+        WHERE email = #{email} AND name = #{name} AND phone = #{phone} AND is_active = 0
     </update>
 </mapper>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #79
- close : #79
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## ✅ 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- User 도메인에 phone 칼럼 추가
- 아이디 찾기 기능 추가
- 비밀번호 찾기(재설정) 기능 추가
- 이메일 중복 확인 API 분리
- 프로필 수정 로직 수정
- 보안 설정 추가
- UNIQUE 제약 위반 전역 예외 처리 추가

## 📸 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->
<img width="321" height="160" alt="image" src="https://github.com/user-attachments/assets/1a9a9099-e30a-4729-bb7f-b96a59970bb5" />

## 🗨️ 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- USERS 테이블에 phone 칼럼 UNIQUE 조건으로 추가하였습니다.
