### PR TITLE
Feat: 챗봇 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     </scm>
     <properties>
         <java.version>17</java.version>
+        <spring-ai.version>1.1.2</spring-ai.version>
     </properties>
     <dependencies>
         <dependency>
@@ -101,8 +102,25 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
+        <!--   Spring AI     -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-model-openai</artifactId>
+        </dependency>
 
     </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.ai</groupId>
+                <artifactId>spring-ai-bom</artifactId>
+                <version>${spring-ai.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
 
     <build>
         <plugins>

--- a/src/main/java/com/eateum/eateumbe/chat/application/ChatService.java
+++ b/src/main/java/com/eateum/eateumbe/chat/application/ChatService.java
@@ -1,0 +1,24 @@
+package com.eateum.eateumbe.chat.application;
+
+import com.eateum.eateumbe.chat.memory.ChatMessage;
+
+import java.util.List;
+
+/**
+ * 챗봇 기능의 진입점 인터페이스
+ * - 회원 / 비회원 챗봇 처리 흐름을 정의한다.
+ */
+public interface ChatService {
+
+    //비회원
+    String chatForGuest(String sessionId, String message);
+
+    //ChatResponse
+    public String chatForMember(String userId, String message);
+
+    //비회원 히스토리 조회
+    List<ChatMessage> getHistoryForGuest(String sessionId);
+
+    //회원 히스토리 조회
+    List<ChatMessage> getHistoryForMember(String userId);
+}

--- a/src/main/java/com/eateum/eateumbe/chat/application/ChatService.java
+++ b/src/main/java/com/eateum/eateumbe/chat/application/ChatService.java
@@ -14,7 +14,7 @@ public interface ChatService {
     String chatForGuest(String sessionId, String message);
 
     //ChatResponse
-    public String chatForMember(String userId, String message);
+    String chatForMember(String userId, String message);
 
     //비회원 히스토리 조회
     List<ChatMessage> getHistoryForGuest(String sessionId);

--- a/src/main/java/com/eateum/eateumbe/chat/application/ChatServiceImpl.java
+++ b/src/main/java/com/eateum/eateumbe/chat/application/ChatServiceImpl.java
@@ -1,0 +1,291 @@
+package com.eateum.eateumbe.chat.application;
+
+import com.eateum.eateumbe.chat.context.dto.UserChatContext;
+import com.eateum.eateumbe.chat.memory.ChatMemory;
+import com.eateum.eateumbe.chat.memory.ChatMemoryRouter;
+import com.eateum.eateumbe.chat.memory.ChatMessage;
+import com.eateum.eateumbe.chat.memory.RedisChatMemory;
+import com.eateum.eateumbe.chat.context.service.ChatContextFormatter;
+import com.eateum.eateumbe.chat.context.service.UserChatContextService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.chat.prompt.PromptTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 챗봇 핵심 서비스 구현체
+ *
+ * 역할:
+ * - 회원 / 비회원 요청 분기
+ * - 대화 메모리 조회 및 저장
+ * - 사용자 컨텍스트를 Propt에 결합
+ * - AI 호출
+ */
+@Service
+@RequiredArgsConstructor
+public class ChatServiceImpl implements  ChatService {
+    
+    private final ChatModel chatModel; //AI 호출 엔진
+    private final ChatMemoryRouter memoryRouter; //대화 메모리
+    private final UserChatContextService userChatContextService; //회원 컨텍스트
+    private final RedisChatMemory redisChatMemory;
+
+    //비회원
+    public String chatForGuest(String sessionId, String message) {
+
+        ChatMemory memory = memoryRouter.getForGuest();
+        String key = sessionId;
+
+        List<ChatMessage> history = memory.load(key);
+
+        Prompt prompt = buildPromptForGuest(history, message);
+        String answer = callAi(prompt);
+
+        memory.save(key, new ChatMessage(ChatMessage.Role.USER, message));
+        memory.save(key, new ChatMessage(ChatMessage.Role.ASSISTANT, answer));
+
+        return answer;
+    }
+
+    //회원
+    @Override
+    public String chatForMember(String userId, String message) {
+
+        ChatMemory memory = memoryRouter.getForMember();
+
+        //이전 대화 기록 로드
+        List<ChatMessage> history = memory.load(userId);
+
+        boolean isFirstAfterExpire = history.isEmpty();
+
+        if(isFirstAfterExpire) {
+            history.add(
+                    new ChatMessage(ChatMessage.Role.SYSTEM,
+                            """
+                                    이전 대화는 요약만 남아있습니다.
+                                    이전에 이야기했던 맥락을 참고해 대화를 이어가 주세요. 
+                                    """)
+            );
+        }
+
+        //요약 로드 (없으면 null)
+        String summary = redisChatMemory.loadSummary(userId);
+
+        //DB에서 회원 컨텍스트 로드
+        UserChatContext context = userChatContextService.load(userId);
+        String contextText = ChatContextFormatter.format(context);
+
+        //이전 대화 + 새 질문으로 Prompt 생성
+        Prompt prompt = buildPromptForMember(history, summary, contextText, message); //최근대화+ 요약 + 개인정보 + 새 질문
+
+//        logPrompt("MEMBER", userId, prompt); //프롬프트 디버깅용
+
+        //AI 호출
+        String answer = callAi(prompt);
+
+        //대화 저장
+        memory.save(userId, new ChatMessage(ChatMessage.Role.USER, message));
+        memory.save(userId, new ChatMessage(ChatMessage.Role.ASSISTANT, answer));
+
+        return answer;
+    }
+
+    //Prompt 빌더
+    private Prompt buildPromptForGuest(List<ChatMessage> history, String message) {
+
+        String conversationHistory = buildConversationHistory(history);
+
+        PromptTemplate template = new PromptTemplate("""
+            너는 요리 서비스 EATEUM의 챗봇이야.
+            처음 방문한 사용자에게 서비스를 설명하는 역할이야.
+            
+            서비스 규칙:
+            - 비회원도 '내 냉장고 레시피 추천받기' 기능에서는
+              기본 재료(돼지고기, 스팸, 달걀, 김치, 라면, 양파, 파)로
+              레시피 추천을 받을 수 있다.
+            - 하지만 이 챗봇에서는 레시피를 직접 추천하지 않는다.
+            - 챗봇에서는 기능 설명, 사용 방법, 요리 관련 일반 정보만 제공한다.
+            - 더 많은 재료 기반 추천이나 개인화 기능은 회원 전용이다.
+            
+            말투:
+            - 반말 X
+            - 과도한 이모지 X
+            - 친근하지만 정보 위주
+            
+            답변 가이드:
+            - 레시피 추천 요청이 오면
+             → 해당 기능은 '내 냉장고 레시피 추천받기'에서 이용 가능하다고 안내한다.
+            - 기본 재료를 벗어난 추천 요청이 오면
+             → 회원 가입 시 가능한 기능임을 설명한다.
+            - 답변은 친절하고 간결하게 한다.
+            
+            이전 대화: {history}
+            
+            사용자 질문: {message}
+        """);
+
+        return template.create(Map.of(
+                "history", conversationHistory,
+                "message", message
+        ));
+    }
+
+    private Prompt buildPromptForMember(List<ChatMessage> history, String summary, String context, String message) {
+
+        String conversationHistory = buildConversationHistory(history);
+        String safeSummary = (summary == null) ? "" : summary;
+
+        PromptTemplate template = new PromptTemplate("""
+            너는 요리 서비스 EATEUM의 개인 맞춤 챗봇이야.
+            이전 대화가 일부 생략될 수 있지만,
+            사용자의 요리 기록과 관심사를 이해한 상태로 대답해.
+            
+            역할:
+            - 사용자의 취향을 이해한 것처럼 자연스럽게 대답한다.
+            - 요리와 관련된 질문에 설명, 팁, 조언을 제공한다.
+            - 이해하기 쉬운 수평적인 말투를 유지한다.
+            
+            영상 및 레시피 정보 활용 규칙:
+            - 사용자가 완료하거나 관심 표시한 레시피에 연결된 유튜브 영상은
+              '요리 맥락을 이해하기 위한 참고 정보'로만 활용한다.
+            - 영상의 특정 장면, 시간, 정확한 발언을 인용하거나
+              실제로 영상을 분석한 것처럼 말하지 않는다.
+            - 일반적인 요리 상식과 경험을 바탕으로 조언한다.
+            
+            레시피 단계 정보 활용 가이드 (recipe_steps):
+            - recipe_steps는 '조리 흐름을 이해하기 위한 참고 자료'로만 사용한다.
+            - 레시피를 단계별로 그대로 재현하거나 나열하지 않는다.
+            - 대신 다음과 같은 방식으로 활용한다:
+              • 특정 재료가 등장하는 단계의 목적 설명
+              • 그 단계에서 자주 발생하는 실수
+              • 대체 가능한 방법이나 선택지
+              • 왜 그 순서가 중요한지에 대한 이유
+            - 예시:
+              ❌ "1단계에서 파를 썰고, 2단계에서 볶는다"
+              ✅ "파를 이 단계에서 넣는 이유는 향을 먼저 내기 위함이에요"
+        
+            - 사용자가 특정 재료나 과정에 대해 물으면,
+              해당 재료가 등장하는 단계의 '의도와 요령' 위주로 답변한다.
+            - recipe_steps는 답변의 '근거'로만 사용하고, 답변에 그대로 노출하지 않는다.
+                
+            정보 활용 우선순위:
+            1. 사용자의 질문과 직접 관련된 recipe_steps
+            2. 관련된 요리 메모 (실수, 팁)
+            3. 최근 완성 / 관심 요리 맥락
+            4. 일반적인 요리 상식
+        
+            - 모든 정보를 다 쓰려고 하지 말고,
+              질문에 가장 도움이 되는 정보만 선택해서 사용한다.
+                
+            허용되는 질문 예시:
+            - 이 요리에서 재료를 다른 재료로 대체해도 될지
+            - 이 요리를 더 맛있게 만드는 팁이나 주의할 점
+            - 특정 재료(파, 마늘 등)을 어떻게 손질하면 좋을지
+            - 요리 선택 시 고려하면 좋은 기준
+            
+            출력 가이드:
+            - 사용자가 "목록", "몇 개", "알려줘"와 같이 나열을 요청하면
+              항목별로 정리해서 답변한다.
+            - 요리 목록을 말할 때는 다음 순서를 따른다:
+              1. 요리 이름
+              2. 관련 메모가 있다면 함께 언급
+            - 목록은 쉼표가 아닌 줄바꿈으로 구분한다.
+            
+            중요 규칙:
+            - 레시피 "추천"은 하지 않는다.
+            - 실제 레시피 선택은 '내 냉장고 레시피 추천받기' 기능에서만 가능하다.
+            - 여기서는 요리 정보, 조리 팁, 선택 기준, 응용방법만 제공한다.
+            - 사용자가 하지 않은 요리 경험을 지어내지 않는다.
+            - 데이터에 없는 정보를 사실처럼 말하지 않는다.
+            - 레시피를 단계별로 상세히 재현하지 않는다.
+            
+            답변 스타일:
+            - 너무 길지 않게 (3~6줄)
+            - 친절하지만 전문가 느낌
+            - 필요하면 자연스러운 질문으로 대화를 이어간다.
+            
+            답변 시작 가이드:
+            - 가능하다면 다음 표현 중 하나로 답변을 시작한다:
+              • "최근에 하신 요리를 보면,"
+              • "아까 말씀하신 요리 기준으로 보면,"
+              • "완성하신 레시피 흐름을 보면,"
+            - 실제로 없는 기억은 만들어내지 않는다.
+            
+            이전 대화 요약: {summary}
+            
+            사용자 정보 요약: {context}
+            
+            최근 대화: {history}
+            
+            사용자 질문: {message}
+            
+            답변 시 유의:
+            - 사용자의 과거 요리/좋아요 기록이 있다면 자연스럽게 언급 가능
+            - 없는 정보는 추측하지 않는다.
+        """);
+
+        return template.create(Map.of(
+                "summary", safeSummary,
+                "context", context,
+                "history", conversationHistory,
+                "message", message
+        ));
+    }
+
+    private String callAi(Prompt prompt) {
+        return chatModel.call(prompt)
+                .getResult()
+                .getOutput()
+                .getText();
+    }
+
+    private String buildConversationHistory(List<ChatMessage> history) {
+        if(history == null || history.isEmpty()) {
+            return "";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (ChatMessage msg : history) {
+            sb.append(msg.getRole().name())
+                    .append(": ")
+                    .append(msg.getContent())
+                    .append("\n");
+        }
+        return sb.toString();
+    }
+    
+    //프롬프트 디버깅용
+//    private void logPrompt(String type, String key, Prompt prompt) {
+//        String text = prompt.getInstructions().toString();
+//        int charLength = text.length();
+//        int estimatedTokens = charLength / 4; //매우 보편적인 추정치
+//
+//        System.out.println("\n==============================");
+//        System.out.println("🧠 CHATBOT PROMPT DEBUG");
+//        System.out.println("TYPE : " + type);
+//        System.out.println("KEY  : " + key);
+//        System.out.println("CHARS : " + charLength);
+//        System.out.println("TOKENS : ~" + estimatedTokens);
+//        System.out.println("------------------------------");
+//
+//        System.out.println(text);
+//
+//        System.out.println("==============================\n");
+//    }
+
+    @Override
+    public List<ChatMessage> getHistoryForGuest(String sessionId) {
+        ChatMemory memory = memoryRouter.getForGuest();
+        return memory.load(sessionId);
+    }
+
+    @Override
+    public List<ChatMessage> getHistoryForMember(String userId) {
+        ChatMemory memory = memoryRouter.getForMember();
+        return memory.load(userId);
+    }
+}

--- a/src/main/java/com/eateum/eateumbe/chat/context/dto/CategoryStat.java
+++ b/src/main/java/com/eateum/eateumbe/chat/context/dto/CategoryStat.java
@@ -1,0 +1,14 @@
+package com.eateum.eateumbe.chat.context.dto;
+
+import lombok.Getter;
+
+/**
+ * 레시피 카테고리 통계
+ */
+@Getter
+public class CategoryStat {
+
+    private String categoryName;
+    private int count;
+    
+}

--- a/src/main/java/com/eateum/eateumbe/chat/context/dto/RecipeBrief.java
+++ b/src/main/java/com/eateum/eateumbe/chat/context/dto/RecipeBrief.java
@@ -1,0 +1,15 @@
+package com.eateum.eateumbe.chat.context.dto;
+
+import lombok.Getter;
+
+/**
+ * 완성 / 좋아요 레시피 공통
+ */
+@Getter
+public class RecipeBrief {
+
+    private Long recipeVideoId;
+    private String videoTitle;
+    private String categoryName;
+
+}

--- a/src/main/java/com/eateum/eateumbe/chat/context/dto/RecipeMemoBrief.java
+++ b/src/main/java/com/eateum/eateumbe/chat/context/dto/RecipeMemoBrief.java
@@ -1,0 +1,14 @@
+package com.eateum.eateumbe.chat.context.dto;
+
+import lombok.Getter;
+
+/**
+ * 레시피 메모
+ */
+@Getter
+public class RecipeMemoBrief {
+    
+    private String videoTitle;
+    private String content;
+    
+}

--- a/src/main/java/com/eateum/eateumbe/chat/context/dto/UserChatContext.java
+++ b/src/main/java/com/eateum/eateumbe/chat/context/dto/UserChatContext.java
@@ -1,0 +1,29 @@
+package com.eateum.eateumbe.chat.context.dto;
+
+import com.eateum.eateumbe.chat.dto.response.RecipeStep;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.awt.*;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 회원 챗봇 응답을 위한 사용자 컨텍스트 데이터
+ * - Prompt에 그대로 주입되는 데이터 묶음
+ */
+@Getter
+@Builder
+public class UserChatContext {
+
+    private List<RecipeBrief> recentCompleted;
+
+    private List<RecipeBrief> recentLiked;
+
+    private List<CategoryStat> topCategories;
+
+    private List<RecipeMemoBrief> recentMemos;
+
+    private List<RecipeStep> recipeSteps;
+
+}

--- a/src/main/java/com/eateum/eateumbe/chat/context/dto/UserChatContext.java
+++ b/src/main/java/com/eateum/eateumbe/chat/context/dto/UserChatContext.java
@@ -4,9 +4,7 @@ import com.eateum.eateumbe.chat.dto.response.RecipeStep;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.awt.*;
 import java.util.List;
-import java.util.Map;
 
 /**
  * 회원 챗봇 응답을 위한 사용자 컨텍스트 데이터

--- a/src/main/java/com/eateum/eateumbe/chat/context/service/ChatContextFormatter.java
+++ b/src/main/java/com/eateum/eateumbe/chat/context/service/ChatContextFormatter.java
@@ -1,0 +1,108 @@
+package com.eateum.eateumbe.chat.context.service;
+
+import com.eateum.eateumbe.chat.context.dto.CategoryStat;
+import com.eateum.eateumbe.chat.context.dto.RecipeBrief;
+import com.eateum.eateumbe.chat.context.dto.RecipeMemoBrief;
+import com.eateum.eateumbe.chat.context.dto.UserChatContext;
+import com.eateum.eateumbe.chat.dto.response.RecipeStep;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 데이터를 요약하는 Formatter
+ * ------------------------------------------------------
+ * 최근에 완성한 요리: 김치찌개(한식), 파스타(양식), 제육볶음(한식)
+ * 최근에 관심을 가진 요리: 마파두부, 카레
+ * 요리 취향 카테고리: 한식, 양식
+ * 요리 메모: "간이 조금 셌음", "불을 약하게 유지"
+ */
+public class ChatContextFormatter {
+    
+    //회원 컨텍스트를 Prompt용 문자열로 반환
+    public static String format(UserChatContext userChatContext) {
+        StringBuilder sb = new StringBuilder();
+
+        appendRecentCompleted(sb, userChatContext.getRecentCompleted());
+        appendRecentLiked(sb, userChatContext.getRecentLiked());
+        appendTopCategories(sb, userChatContext.getTopCategories());
+        appendRecentMemos(sb, userChatContext.getRecentMemos());
+        appendRecipeSteps(sb, userChatContext.getRecipeSteps());
+
+        return sb.toString().trim();
+    }
+
+    private static void appendRecentCompleted(StringBuilder sb, List<RecipeBrief> list) {
+        if (list == null || list.isEmpty()) return; //비어있으면 넣지 않음 > prompt 짧게 유지
+
+        sb.append("최근에 완성한 요리 : ");
+        sb.append(
+                list.stream()
+                        .map(recipe -> recipe.getVideoTitle() + "(" + recipe.getCategoryName() + ")")
+                        .collect(Collectors.joining(", "))
+        );
+        sb.append("\n");
+    }
+
+    private static void appendRecentLiked(StringBuilder sb, List<RecipeBrief> list) {
+        if (list == null || list.isEmpty()) return;
+
+        sb.append("최근에 관심을 가진 요리 : ");
+        sb.append(
+                list.stream()
+                        .map(RecipeBrief::getVideoTitle)
+                        .collect(Collectors.joining(", "))
+        );
+        sb.append("\n");
+    }
+
+    private static void appendTopCategories(StringBuilder sb, List<CategoryStat> list) {
+        if (list == null || list.isEmpty()) return;
+
+        sb.append("요리 취향 카테고리 : ");
+        sb.append(
+                list.stream()
+                        .map(CategoryStat::getCategoryName)
+                        .collect(Collectors.joining(", "))
+        );
+        sb.append("\n");
+    }
+
+    private static void appendRecentMemos(StringBuilder sb, List<RecipeMemoBrief> list) {
+        if (list == null || list.isEmpty()) return;
+
+        sb.append("요리 메모 : ");
+        sb.append(
+                list.stream()
+                        .map(memo -> "\"" + memo.getContent() + "\"")
+                        .collect(Collectors.joining(", "))
+        );
+        sb.append("\n");
+    }
+
+    private static void appendRecipeSteps(
+            StringBuilder sb,
+            List<RecipeStep> recipeSteps
+    ) {
+        if (recipeSteps == null || recipeSteps.isEmpty()) return;
+
+        sb.append("요리 단계 정보:\n");
+
+        for (RecipeStep step : recipeSteps) {
+            sb.append("- [")
+                    .append(step.getRecipeVideoId())
+                    .append(" / ")
+                    .append(step.getStepNumber())
+                    .append("단계] ");
+
+            if (step.getStepTitle() != null) {
+                sb.append(step.getStepTitle()).append(" : ");
+            }
+
+            sb.append(step.getContent()).append("\n");
+        }
+    }
+
+    
+}

--- a/src/main/java/com/eateum/eateumbe/chat/context/service/ChatContextFormatter.java
+++ b/src/main/java/com/eateum/eateumbe/chat/context/service/ChatContextFormatter.java
@@ -7,7 +7,6 @@ import com.eateum.eateumbe.chat.context.dto.UserChatContext;
 import com.eateum.eateumbe.chat.dto.response.RecipeStep;
 
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 /**

--- a/src/main/java/com/eateum/eateumbe/chat/context/service/UserChatContextService.java
+++ b/src/main/java/com/eateum/eateumbe/chat/context/service/UserChatContextService.java
@@ -1,0 +1,13 @@
+package com.eateum.eateumbe.chat.context.service;
+
+import com.eateum.eateumbe.chat.context.dto.UserChatContext;
+
+/**
+ * 회원 챗봇용 사용자 컨텍스트 조회 서비스
+ * - DB에서 챗봇에 필요한 사용자 정보만 선별 조회
+ */
+public interface UserChatContextService {
+
+    UserChatContext load(String userId);
+    
+}

--- a/src/main/java/com/eateum/eateumbe/chat/context/service/UserChatContextServiceImpl.java
+++ b/src/main/java/com/eateum/eateumbe/chat/context/service/UserChatContextServiceImpl.java
@@ -1,0 +1,45 @@
+package com.eateum.eateumbe.chat.context.service;
+
+import com.eateum.eateumbe.chat.context.dto.RecipeBrief;
+import com.eateum.eateumbe.chat.context.dto.UserChatContext;
+import com.eateum.eateumbe.chat.dto.response.RecipeStep;
+import com.eateum.eateumbe.chat.repository.ChatbotMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * UserChatContextService 구현체
+ * - 여러 테이블 조회 결과를 조합하여 UserChatContext 객체를 생성
+ */
+@Service
+@RequiredArgsConstructor
+public class UserChatContextServiceImpl implements UserChatContextService {
+
+    private final ChatbotMapper chatbotMapper;
+
+    @Override
+    public UserChatContext load(String userId) {
+
+        List<RecipeBrief> completed = chatbotMapper.selectRecentCompletedRecipes(userId);
+        List<RecipeBrief> liked = chatbotMapper.selectRecentLikedRecipes(userId);
+
+        //레시피 ID 수집 (중복제거)
+        List<Long> recipeVideoIds = Stream.concat(completed.stream(), liked.stream())
+                .map(RecipeBrief::getRecipeVideoId)
+                .distinct()
+                .toList();
+
+        List<RecipeStep> steps = recipeVideoIds.isEmpty() ? List.of() : chatbotMapper.selectStepsByRecipeIds(recipeVideoIds);
+
+        return UserChatContext.builder()
+                .recentCompleted(completed)
+                .recentLiked(liked)
+                .topCategories(chatbotMapper.selectTopCategories(userId))
+                .recentMemos(chatbotMapper.selectRecentMemos(userId))
+                .recipeSteps(steps)
+                .build();
+    }
+}

--- a/src/main/java/com/eateum/eateumbe/chat/controller/ChatController.java
+++ b/src/main/java/com/eateum/eateumbe/chat/controller/ChatController.java
@@ -1,0 +1,60 @@
+package com.eateum.eateumbe.chat.controller;
+
+import com.eateum.eateumbe.chat.dto.request.ChatRequest;
+import com.eateum.eateumbe.chat.dto.response.ChatResponse;
+import com.eateum.eateumbe.chat.application.ChatService;
+import com.eateum.eateumbe.chat.memory.ChatMessage;
+import com.eateum.eateumbe.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 챗봇 API 컨트롤러
+ * - 비회원 챗봇 (세션 기반)
+ * - 회원 챗봇 (JWT + Redis 메모리)
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/chat")
+public class ChatController {
+
+    private final ChatService chatService;
+
+    //비회원 챗봇 - sessionId 있으면 대화 유지, 없으면 서버에서 생성
+    @PostMapping("/guest")
+    public ChatResponse chatForGuest(
+            @RequestHeader(value = "X-Chat-Session-Id", required = false) String sessionId, //세션ID 하나 받기
+            @RequestBody ChatRequest chatRequest
+    ) {
+        String actualSessionId = (sessionId != null) ? sessionId : UUID.randomUUID().toString();
+        String answer = chatService.chatForGuest(actualSessionId, chatRequest.getMessage());
+        return new ChatResponse(answer, actualSessionId);
+    }
+
+    //회원 챗봇 - Redis 기반 기억
+    @PostMapping("/member")
+    public ChatResponse chatForMember(
+            @AuthenticationPrincipal String userId,
+            @RequestBody ChatRequest chatRequest)
+    {
+        String answer = chatService.chatForMember(userId, chatRequest.getMessage());
+        return new ChatResponse(answer, null);
+    }
+
+    //비회원 히스토리 조회
+    @GetMapping("/guest/history")
+    public ApiResponse<List<ChatMessage>> getGuestHistory(@RequestHeader("X-Chat-Session-Id") String sessionId) {
+        return ApiResponse.success(chatService.getHistoryForGuest(sessionId));
+    }
+
+    //회원 히스토리 조회
+    @GetMapping("/member/history")
+    public ApiResponse<List<ChatMessage>> getMemberHistory(@AuthenticationPrincipal String userId) {
+        return ApiResponse.success(chatService.getHistoryForMember(userId));
+    }
+
+}

--- a/src/main/java/com/eateum/eateumbe/chat/dto/request/ChatRequest.java
+++ b/src/main/java/com/eateum/eateumbe/chat/dto/request/ChatRequest.java
@@ -1,0 +1,17 @@
+package com.eateum.eateumbe.chat.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 챗봇 요청 DTO (사용자 입력 메시지)
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatRequest {
+
+    private String message;
+
+}

--- a/src/main/java/com/eateum/eateumbe/chat/dto/response/ChatResponse.java
+++ b/src/main/java/com/eateum/eateumbe/chat/dto/response/ChatResponse.java
@@ -1,0 +1,21 @@
+package com.eateum.eateumbe.chat.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 챗봇 응답 DTO
+ * - AI 응답 메시지
+ * - 비회원 세션 ID (필요 시)
+ */
+@Getter
+@AllArgsConstructor
+public class ChatResponse {
+
+    private String answer;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL) //null이면 JSON에 나가지 않음
+    private String sessionId;
+
+}

--- a/src/main/java/com/eateum/eateumbe/chat/dto/response/RecipeStep.java
+++ b/src/main/java/com/eateum/eateumbe/chat/dto/response/RecipeStep.java
@@ -1,0 +1,18 @@
+package com.eateum.eateumbe.chat.dto.response;
+
+import lombok.Data;
+
+/**
+ * 레시피 단계 정보 DTO
+ * - AI가 요리 맥락을 이해하기 위한 참고 데이터
+ */
+@Data
+public class RecipeStep {
+
+    private Long stepId;
+    private Long recipeVideoId;
+    private Integer stepNumber;
+    private String stepTitle;
+    private String content;
+
+}

--- a/src/main/java/com/eateum/eateumbe/chat/memory/ChatMemory.java
+++ b/src/main/java/com/eateum/eateumbe/chat/memory/ChatMemory.java
@@ -1,0 +1,20 @@
+package com.eateum.eateumbe.chat.memory;
+
+import org.springframework.ai.openai.api.OpenAiApi;
+
+import java.util.List;
+
+/**
+ * 챗봇 대화 메모리 인터페이스
+ */
+public interface ChatMemory {
+
+    //사용자별 대화 기록 조회
+    List<ChatMessage> load(String userId);
+
+    //사용자 대화 저장
+    void save(String userId, ChatMessage message);
+
+    //대화 기록 초기화
+    void clear(String userId);
+}

--- a/src/main/java/com/eateum/eateumbe/chat/memory/ChatMemory.java
+++ b/src/main/java/com/eateum/eateumbe/chat/memory/ChatMemory.java
@@ -1,7 +1,5 @@
 package com.eateum.eateumbe.chat.memory;
 
-import org.springframework.ai.openai.api.OpenAiApi;
-
 import java.util.List;
 
 /**

--- a/src/main/java/com/eateum/eateumbe/chat/memory/ChatMemoryRouter.java
+++ b/src/main/java/com/eateum/eateumbe/chat/memory/ChatMemoryRouter.java
@@ -1,0 +1,23 @@
+package com.eateum.eateumbe.chat.memory;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * 회원 / 비회원에 따라 사용할 ChatMemory 구현체 분기 전용 클래스
+ */
+@Component
+@RequiredArgsConstructor
+public class ChatMemoryRouter {
+
+    private final RedisChatMemory redisChatMemory;
+    private final InMemoryChatMemory inMemoryChatMemory;
+
+    public ChatMemory getForMember() {
+        return redisChatMemory;
+    }
+
+    public ChatMemory getForGuest() {
+        return inMemoryChatMemory;
+    }
+}

--- a/src/main/java/com/eateum/eateumbe/chat/memory/ChatMessage.java
+++ b/src/main/java/com/eateum/eateumbe/chat/memory/ChatMessage.java
@@ -1,0 +1,23 @@
+package com.eateum.eateumbe.chat.memory;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 챗봇 대화 메시지 단위 객체
+ * - USER / ASSISTANT 역할 구분
+ * - 메모리 저장용
+ */
+@Getter
+@AllArgsConstructor
+public class ChatMessage {
+
+    private Role role;
+    private String content;
+
+    public enum Role {
+        USER,
+        ASSISTANT,
+        SYSTEM
+    }
+}

--- a/src/main/java/com/eateum/eateumbe/chat/memory/InMemoryChatMemory.java
+++ b/src/main/java/com/eateum/eateumbe/chat/memory/InMemoryChatMemory.java
@@ -1,0 +1,43 @@
+package com.eateum.eateumbe.chat.memory;
+
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+/**
+ * 인메모리 용 구현 클래스 (비회원용)
+ * - 서버 재시작시 초기화
+ * - 간단한 세션 유지용
+ */
+@Component
+public class InMemoryChatMemory implements ChatMemory {
+
+    private static final int MAX_MESSAGE = 20; //최근 대화 20개만 저장
+    private final Map<String, Deque<ChatMessage>> store = new HashMap<>(); //userId별 대화 저장
+
+    //사용자의 지금까지 대화 기록 가져오기
+    @Override
+    public List<ChatMessage> load(String userId) {
+        //있으면 기존대화, 없으면 빈 대화 > 복사본으로 반환
+        return new ArrayList<>(store.getOrDefault(userId, new ArrayDeque<>()));
+    }
+
+    //사용자의 대화 한 줄을 저장
+    @Override
+    public void save(String userId, ChatMessage message) {
+        //있으면 기존 Deque, 없으면 새 Deque만들어 Map에 저장
+        Deque<ChatMessage> messages = store.computeIfAbsent(userId, k -> new ArrayDeque<>());
+
+        messages.addLast(message); //최신 대화는 맨 뒤
+
+        while (messages.size() > MAX_MESSAGE) { //용량 초과하면
+            messages.removeFirst(); //가장 오래된 메세지 제거
+        }
+    }
+    
+    //사용자의 모든 대화 기록 삭제
+    @Override
+    public void clear(String userId) {
+        store.remove(userId);
+    }
+}

--- a/src/main/java/com/eateum/eateumbe/chat/memory/RedisChatMemory.java
+++ b/src/main/java/com/eateum/eateumbe/chat/memory/RedisChatMemory.java
@@ -1,0 +1,119 @@
+package com.eateum.eateumbe.chat.memory;
+
+import com.eateum.eateumbe.chat.summary.ChatSummaryService;
+import com.eateum.eateumbe.global.error.ApiException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Redis 용 구현 클래스 (회원)
+ * - TTL 기반
+ * - 최근 대화 개수 제한
+ * - 요약 저장 기능
+ */
+@Component
+@RequiredArgsConstructor
+public class RedisChatMemory implements ChatMemory {
+
+    private static final int MAX_MESSAGES = 20;
+    private static final Duration TTL = Duration.ofMinutes(30);
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper; //JSON <> ChatMessage 객체
+    private final ChatSummaryService chatSummaryService; //과거 내용 요약
+
+    @Override
+    public List<ChatMessage> load(String userId) {
+        String key = generateKey(userId);
+
+        List<String> values = redisTemplate.opsForList().range(key, 0, -1); //Redis 리스트 전체 조회
+
+        if(values == null) {
+            return List.of();
+        }
+
+        List<ChatMessage> messages = new ArrayList<>();
+        for(String value : values) {
+            messages.add(deserialize(value)); //JSON > ChatMessage로 변환
+        }
+
+        return messages;
+
+    }
+
+    @Override
+    public void save(String userId, ChatMessage message) {
+        String key = generateKey(userId);
+
+        redisTemplate.opsForList().rightPush(key, serialize(message)); //최신 메시지를 맨 뒤에 추가
+
+        Long size = redisTemplate.opsForList().size(key);
+
+        if(size != null && size >= MAX_MESSAGES) {
+            //기존 대화 로드
+            List<ChatMessage> history = load(userId);
+            //요약 생성
+            String summary = chatSummaryService.summarize(history);
+            //요약 저장
+            saveSummary(userId, summary);
+
+            //최근 대화만 남김
+            redisTemplate.opsForList().trim(key, -10, -1);
+        }
+        //TTL 갱신
+        redisTemplate.expire(key, TTL); //대화가 이어질 때마다 TTL 갱신 > 최근 30분간 대화한 사용자만 기억
+    }
+
+    @Override
+    public void clear(String userId) {
+        redisTemplate.delete(generateKey(userId)); //Redis에서 키 자체 제거
+    }
+
+    private String generateKey(String userId) {
+        return "chat:memory:" + userId; //chat:memory:{userId}로 확인
+    }
+
+    private String serialize(ChatMessage message) {
+        try {
+            return objectMapper.writeValueAsString(message);
+        } catch (JsonProcessingException e) {
+            throw new ApiException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "대화 기록을 저장하는 중 오류가 발생했습니다."
+            );
+        }
+    }
+
+    //요약 조회 - prompt 만들 때 사용
+    public String loadSummary(String userId) {
+        String key = "chat:summary:" + userId;
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    //요약 저장
+    private void saveSummary(String userId, String summary) {
+        String key = "chat:summary:" + userId;
+
+        redisTemplate.opsForValue().set(key, summary, Duration.ofDays(1)); //요약은 좀 더 오래 유지한다.
+    }
+
+    private ChatMessage deserialize(String value) {
+        try {
+            return objectMapper.readValue(value, ChatMessage.class);
+        } catch (JsonProcessingException e) {
+            throw new ApiException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "대화 기록을 불러오는 중 오류가 발생했습니다."
+            );
+        }
+    }
+
+}

--- a/src/main/java/com/eateum/eateumbe/chat/repository/ChatbotMapper.java
+++ b/src/main/java/com/eateum/eateumbe/chat/repository/ChatbotMapper.java
@@ -1,0 +1,33 @@
+package com.eateum.eateumbe.chat.repository;
+
+import com.eateum.eateumbe.chat.context.dto.CategoryStat;
+import com.eateum.eateumbe.chat.context.dto.RecipeBrief;
+import com.eateum.eateumbe.chat.context.dto.RecipeMemoBrief;
+import com.eateum.eateumbe.chat.dto.response.RecipeStep;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+/**
+ * 챗봇 전용 Mapper
+ */
+@Mapper
+public interface ChatbotMapper {
+    
+    //최근 완성 레시피
+    List<RecipeBrief> selectRecentCompletedRecipes(@Param("userId") String userId);
+
+    //최근 좋아요 레시피
+    List<RecipeBrief> selectRecentLikedRecipes(@Param("userId") String userId);
+
+    //선호 카테고리
+    List<CategoryStat> selectTopCategories(@Param("userId") String userId);
+
+    //최근 메모
+    List<RecipeMemoBrief> selectRecentMemos(@Param("userId") String userId);
+
+    //레시피 단계
+    List<RecipeStep> selectStepsByRecipeIds(@Param("recipeVideoIds") List<Long> recipeVideoIds);
+
+}

--- a/src/main/java/com/eateum/eateumbe/chat/summary/ChatSummaryService.java
+++ b/src/main/java/com/eateum/eateumbe/chat/summary/ChatSummaryService.java
@@ -1,0 +1,16 @@
+package com.eateum.eateumbe.chat.summary;
+
+import com.eateum.eateumbe.chat.memory.ChatMessage;
+
+import java.util.List;
+
+/**
+ * 챗봇 대화 요약 서비스
+ * - 대화가 길어질 경우 요약 생성
+ */
+public interface ChatSummaryService {
+    
+    //대화 내용을 요약해서 한 줄로 반환
+    String summarize(List<ChatMessage> messages);
+    
+}

--- a/src/main/java/com/eateum/eateumbe/chat/summary/ChatSummaryServiceImpl.java
+++ b/src/main/java/com/eateum/eateumbe/chat/summary/ChatSummaryServiceImpl.java
@@ -1,0 +1,39 @@
+package com.eateum.eateumbe.chat.summary;
+
+import com.eateum.eateumbe.chat.memory.ChatMessage;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * ChatSummaryService 구현체
+ * - 이전 대화를 요약하여 Redis에 저장
+ * Prompt 길이 관리 목적
+ */
+@Service
+public class ChatSummaryServiceImpl implements ChatSummaryService {
+
+    @Override
+    public String summarize(List<ChatMessage> messages) {
+
+        if (messages == null || messages.isEmpty()) {
+            return "";
+        }
+
+        //최근 사용자 대화 위주로 요약
+        List<String> userMessages = messages.stream()
+                .filter(message -> message.getRole() == ChatMessage.Role.USER)
+                .map(ChatMessage::getContent)
+                .limit(5)
+                .collect(Collectors.toList());
+
+        if (userMessages.isEmpty()) {
+            return "";
+        }
+
+        return "이전 대화 요약: 사용자는 최근에 "
+                + String.join(", ", userMessages)
+                + " 등에 대해 질문했다.";
+    }
+}

--- a/src/main/java/com/eateum/eateumbe/global/config/ChatConfig.java
+++ b/src/main/java/com/eateum/eateumbe/global/config/ChatConfig.java
@@ -1,0 +1,21 @@
+package com.eateum.eateumbe.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class ChatConfig {
+
+    //AI 서버로 나가는 모든 요청에 대한 공통 RestClient 설정
+    @Bean
+    public RestClient.Builder restClientBuilder() {
+        return RestClient.builder()
+                .requestInterceptor(((request, body, execution) -> {
+                    request.getHeaders().set("Content-Type", "application/json");
+                    return execution.execute(request, body);
+                }));
+    }
+
+
+}

--- a/src/main/java/com/eateum/eateumbe/global/config/SecurityConfig.java
+++ b/src/main/java/com/eateum/eateumbe/global/config/SecurityConfig.java
@@ -86,17 +86,20 @@ public class SecurityConfig {
                             "/user/reissue",
                             "/user/logout",
                             "/user/find/id",
-                            "/user/find/password"
+                            "/user/find/password",
+                            "/chat/guest"
                     ).permitAll()
 
                     .requestMatchers(HttpMethod.GET,
-                            "user/email/check"
+                            "user/email/check",
+                            "/chat/guest/history"
                     ).permitAll()
 
-                    //그 외 user는 전부 인증 필요
+                    //그 외는 전부 인증 필요
                     .requestMatchers("/user/**").authenticated()
                     .requestMatchers("/recipes/*/memo/**").authenticated()
                     .requestMatchers("/recipes/my/**").authenticated()
+                    .requestMatchers("/chat/**").authenticated()
 
                     //나머지 API는 일단 열어두고 추후 수정
                     .anyRequest().permitAll()

--- a/src/main/java/com/eateum/eateumbe/global/security/JwtVerificationFilter.java
+++ b/src/main/java/com/eateum/eateumbe/global/security/JwtVerificationFilter.java
@@ -106,6 +106,7 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
                 || path.startsWith("/user/find/id")
                 || path.startsWith("/user/find/password")
                 || path.startsWith("/user/email/check")
+                || path.startsWith("/chat/guest")
                 || path.startsWith("/v3/api-docs")
                 || path.startsWith("/swagger-ui");
     }

--- a/src/main/java/com/eateum/eateumbe/user/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/eateum/eateumbe/user/service/auth/AuthServiceImpl.java
@@ -1,5 +1,7 @@
 package com.eateum.eateumbe.user.service.auth;
 
+import com.eateum.eateumbe.chat.memory.ChatMemory;
+import com.eateum.eateumbe.chat.memory.ChatMemoryRouter;
 import com.eateum.eateumbe.global.error.ApiException;
 import com.eateum.eateumbe.global.jwt.JwtProperties;
 import com.eateum.eateumbe.global.jwt.JwtProvider;
@@ -12,6 +14,7 @@ import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -35,6 +38,7 @@ public class AuthServiceImpl implements AuthService {
     private final JwtProvider jwtProvider;
     private final RefreshTokenService refreshTokenService;
     private final JwtProperties jwtProperties;
+    private final ChatMemoryRouter memoryRouter;
 
     /**
      * 로그인 시 비밀번호를 검증하고 JWT토큰을 발행
@@ -148,6 +152,9 @@ public class AuthServiceImpl implements AuthService {
                 //Redis에서 RefreshToken 삭제
                 refreshTokenService.delete(userId);
                 log.info("[Logout] refresh token deleted. userId={}", userId);
+
+                //Redis에서 챗봇 대화 기록 삭제
+                memoryRouter.getForMember().clear(userId);
 
             } catch (Exception e) {
                 //만료 or 위조 토큰이어도 로그아웃은 성공 처리

--- a/src/main/java/com/eateum/eateumbe/user/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/eateum/eateumbe/user/service/auth/AuthServiceImpl.java
@@ -1,6 +1,5 @@
 package com.eateum.eateumbe.user.service.auth;
 
-import com.eateum.eateumbe.chat.memory.ChatMemory;
 import com.eateum.eateumbe.chat.memory.ChatMemoryRouter;
 import com.eateum.eateumbe.global.error.ApiException;
 import com.eateum.eateumbe.global.jwt.JwtProperties;
@@ -14,7 +13,6 @@ import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.crypto.password.PasswordEncoder;

--- a/src/main/resources/mapper/ChatbotMapper.xml
+++ b/src/main/resources/mapper/ChatbotMapper.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.eateum.eateumbe.chat.repository.ChatbotMapper">
+
+    <!--  최근 완성 레시피  -->
+    <select id="selectRecentCompletedRecipes" resultType="RecipeBrief">
+        SELECT
+            rv.recipe_video_id,
+            rv.video_title,
+            rv.video_url,
+            c.category_name
+        FROM completed_recipe cr
+        JOIN recipe_video rv ON cr.recipe_video_id = rv.recipe_video_id
+        LEFT JOIN category c ON rv.category_id = c.category_id
+        WHERE cr.user_id = #{userId}
+        ORDER BY cr.completed_at DESC
+        LIMIT 3
+    </select>
+
+    <!--  최근 좋아요 레시피  -->
+    <select id="selectRecentLikedRecipes" resultType="RecipeBrief">
+        SELECT
+            rv.recipe_video_id,
+            rv.video_title,
+            rv.video_url,
+            c.category_name
+        FROM liked_recipe lr
+        JOIN recipe_video rv ON lr.recipe_video_id = rv.recipe_video_id
+        LEFT JOIN category c ON rv.category_id = c.category_id
+        WHERE lr.user_id = #{userId}
+        ORDER BY lr.created_at DESC
+        LIMIT 3
+    </select>
+
+    <!--  선호 카테고리  -->
+    <select id="selectTopCategories" resultType="CategoryStat">
+        SELECT
+            c.category_name,
+            COUNT(*) AS count
+        FROM completed_recipe cr
+        JOIN recipe_video rv ON cr.recipe_video_id = rv.recipe_video_id
+        JOIN category c ON rv.category_id = c.category_id
+        WHERE cr.user_id = #{userId}
+        GROUP BY c.category_name
+        ORDER BY count DESC
+        LIMIT 3
+    </select>
+
+    <!--  최근 메모  -->
+    <select id="selectRecentMemos" resultType="RecipeMemoBrief">
+        SELECT
+            rv.video_title,
+            rv.video_url,
+            rm.content
+        FROM recipe_memo rm
+        JOIN recipe_video rv ON rm.recipe_video_id = rv.recipe_video_id
+        WHERE rm.user_id = #{userId}
+        ORDER BY rm.created_at DESC
+        LIMIT 3
+    </select>
+
+    <!--  레시피 단계  -->
+    <select id="selectStepsByRecipeIds" resultType="RecipeStep">
+        SELECT
+        step_id,
+        recipe_video_id,
+        step_number,
+        step_title,
+        content
+        FROM recipe_steps
+        WHERE recipe_video_id IN
+        <foreach collection="recipeVideoIds" item="id"
+                 open="(" close=")" separator=",">
+            #{id}
+        </foreach>
+        ORDER BY recipe_video_id, step_number
+    </select>
+
+</mapper>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #28
- close : #28 #27
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## ✅ 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
1. **챗봇 도메인 구조 설계 및 패키지 정리**
   - chat 도메인을 Controller / Application(Service) / Context / Memory / Repository / Summary 구조로 분리
   - 역할과 책임이 명확하도록 패키지 재구성

2. **회원 / 비회원 챗봇 분기 처리**
   - 비회원: 세션 ID 기반 InMemory 대화 유지
   - 회원: JWT 인증 + Redis 기반 대화 메모리 사용
   - ChatMemory 인터페이스를 중심으로 메모리 전략 분리

3. **Redis 기반 대화 히스토리 관리**
   - 대화 메시지 개수 제한 및 TTL 적용
   - TTL 만료 후 첫 대화 시 시스템 메시지를 통한 자연스러운 초기화 처리
   - 회원 로그아웃 시 Redis 대화 메모리 정리

4. **회원 챗봇 사용자 컨텍스트 구성**
   - 최근 완성 레시피 / 좋아요 레시피 / 선호 카테고리 / 요리 메모 조회
   - 최근 3개 기준으로 제한하여 토큰 사용량 최소화
   - UserChatContextService에서 단일 컨텍스트로 조합

5. **레시피 단계(recipe_steps) 데이터 활용**
   - 레시피 단계 전체 조회 후 조리 흐름 이해용 참고 데이터로 활용
   - 단계 나열·재현 금지 규칙을 프롬프트에 명시
   - 재료 대체, 조리 팁, 주의사항 설명에 활용

6. **프롬프트 설계 및 출력 가이드 강화**
   - 회원 / 비회원 프롬프트 완전 분리
   - 레시피 추천 제한, 목록/메모 출력 가이드 명확화
   - 프롬프트 디버깅 로그(문자 수, 토큰 추정) 출력 기능 추가

7. **챗봇 API 및 보안 설정 정리**
   - /chat/guest, /chat/member API 구현
   - 채팅방 UI 대응을 위한 대화 히스토리 조회 API 제공
   - 비회원 챗봇 API JWT 필터 및 Security 예외 경로 설정


## 📸 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

## 🗨️ 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
